### PR TITLE
fix for create-language-file command that does not work as expected in some libraries

### DIFF
--- a/lib/h5p.js
+++ b/lib/h5p.js
@@ -804,7 +804,7 @@ function removeUntranslatables(field, name) {
       }
     }
 
-    if (field !== null && Object.keys(field).length === 0) {
+    if (field !== null && field.length === 0) {
       field = undefined;
     }
   }

--- a/lib/h5p.js
+++ b/lib/h5p.js
@@ -804,7 +804,7 @@ function removeUntranslatables(field, name) {
       }
     }
 
-    if (field !== null && field.length === 0) {
+    if (field !== null && Object.keys(field).length === 0) {
       field = undefined;
     }
   }

--- a/lib/h5p.js
+++ b/lib/h5p.js
@@ -804,7 +804,7 @@ function removeUntranslatables(field, name) {
       }
     }
 
-    if (field.length === 0) {
+    if (field !== null && field.length === 0) {
       field = undefined;
     }
   }

--- a/lib/h5p.js
+++ b/lib/h5p.js
@@ -808,7 +808,7 @@ function removeUntranslatables(field, name) {
       field = undefined;
     }
   }
-  else if (name === undefined || (name !== 'label' && name !== 'description' && name !== 'entity')) {
+  else if (name === undefined || (name !== 'label' && name !== 'description' && name !== 'placeholder' && name !== 'default')) {
     field = undefined;
   }
 

--- a/lib/h5p.js
+++ b/lib/h5p.js
@@ -808,7 +808,7 @@ function removeUntranslatables(field, name) {
       field = undefined;
     }
   }
-  else if (name === undefined || (name !== 'label' && name !== 'description' && name !== 'placeholder' && name !== 'default')) {
+  else if (name === undefined || (name !== 'label' && name !== 'description' && name !== 'entity' && name !== 'placeholder' && name !== 'default')) {
     field = undefined;
   }
 


### PR DESCRIPTION
Hi,
I tried the h5p command 'create-language-file' in preparation to Japanese translation, and I got json output of empty objcet ({}) when using in some libraries including H5P.CoursePresentation.
I traced the codes and found some problems in lib/h5p.js:

line 807:
Referring the length property of the variable 'field' without null check.  It causes error when the field is null and the program aborts abnormally to output "{}".

line 807:
The type of the field is not array but object there, so the length property will be always 'undefined'.  In order to guess the number of properties of an object, using Object.keys(field).length is preferred.

line 811:
According to the translation guide (https://h5p.org/documentation/for-developers/translate-h5p-libraries), the complete list of fields that should be translated is:
- Label
- Placeholder
- Description
- Default

But the current code filters only three names -- label, description and entity.  This doesn't conform to the specification and should be corrected.

I added some changes and it seems to work as expected in my environment.
Could you please review the modified code?

Thanks,
