### PR TITLE
exclude some non-translatables from create-language-file

### DIFF
--- a/lib/h5p.js
+++ b/lib/h5p.js
@@ -808,11 +808,50 @@ function removeUntranslatables(field, name) {
       field = undefined;
     }
   }
-  else if (name === undefined || (name !== 'label' && name !== 'description' && name !== 'entity' && name !== 'placeholder' && name !== 'default')) {
+  else if (name === undefined || itemUntranslatable(name, field)) {
     field = undefined;
   }
 
   return field;
+}
+
+/**
+ * Check if an item is untranslatable.
+ * @param {string} property An object's property.
+ * @param {object} value value of the property.
+ * @return {boolean} true, if item is untranslatable.
+ */
+function itemUntranslatable(property, value) {
+  switch (property) {
+    case 'label':
+      return false;
+      break
+    case 'description':
+      return false;
+      break;
+    case 'entity':
+      return false;
+      break;
+    case 'placeholder':
+      return false;
+      break;
+    case 'default':
+      switch (typeof(value)) {
+        case 'number':
+          return true;
+          break;
+        case 'boolean':
+          return true;
+          break;
+        default:
+          return false;
+          break;
+      }
+      break
+    default:
+      return true;
+      break;
+  }
 }
 
 /**


### PR DESCRIPTION
Language files created by the create-language-file command don't need an object's "default" property if it is of type _number_ or _boolean_ (since they're untranslatable).