### PR TITLE
Fixes apparent typo when reverting to the default widget

### DIFF
--- a/lib/assets/h5p-core/editor/scripts/h5peditor-semantic-structure.js
+++ b/lib/assets/h5p-core/editor/scripts/h5peditor-semantic-structure.js
@@ -149,7 +149,7 @@ H5PEditor.SemanticStructure = (function ($) {
 
       if (!validWidgets.length) {
         // There are no valid widgets, add default
-        validWidgets.push(self.default);
+        validWidgets.push(defaultWidget);
       }
 
       return validWidgets;


### PR DESCRIPTION
- removes the reference to self.default which does not appear to have been assigned to anywhere in the editor semantic structure file. Replaces it with a reference to defaultWidget, which appears to be original developer intended. 