### PR TITLE
Add CI mode on get command, translate repository urls to https in ci mode

### DIFF
--- a/bin/h5p-cli.js
+++ b/bin/h5p-cli.js
@@ -90,8 +90,8 @@ function Spinner(prefix) {
  * Recursive cloning of all libraries in the collection.
  * Will print out status messages along the way.
  */
-function clone(ciMode) {
-  var name = h5p.clone(ciMode, function (error) {
+function clone(fetchWithHttps) {
+  var name = h5p.clone(fetchWithHttps, function (error) {
     var result;
     if (error === -1) {
       result = color.yellow + 'SKIPPED' + color.default + lf;
@@ -104,7 +104,7 @@ function clone(ciMode) {
     }
 
     spinner.stop(result);
-    clone(ciMode);
+    clone(fetchWithHttps);
   });
   if (!name) return; // Nothing to clone.
   var msg = 'Cloning into \'' + color.emphasize + name + color.default + '\'...';
@@ -358,14 +358,14 @@ var commands = [
   },
   {
     name: 'get',
-    syntax: '[--ci] <library>',
+    syntax: '[--https] <library>',
     shortDescription: 'Clone library and all dependencies',
-    description: 'The --ci handle indicates that this operation is performed inside ci and should use https:// urls for git repos.',
+    description: 'The --https handle indicates that git operations should use https:// urls for git repos instead of ssh urls.',
     handler: function () {
       var inputs = Array.prototype.slice.call(arguments);
-      const ciMode = inputs[0] === "--ci";
+      const fetchWithHttps = inputs[0] === "--https";
       var libraries = inputs;
-      if(ciMode) {
+      if(fetchWithHttps) {
         libraries = inputs.slice(1);
       }
       
@@ -378,7 +378,7 @@ var commands = [
       h5p.get(libraries, function (error) {
         var result = (error ? (color.red + 'ERROR: ' + color.default + error) : (color.green + 'DONE' + color.default));
         spinner.stop(result + lf);
-        clone(ciMode);
+        clone(fetchWithHttps);
       });
     }
   },

--- a/lib/h5p.js
+++ b/lib/h5p.js
@@ -136,10 +136,19 @@ function getLibrary(libraryName, next) {
   });
 }
 
+function sshToHttps(url){
+  return url.replace("git@github.com:", "https://github.com/");
+}
+
 /**
  * Clone repo at given url into given dir.
  */
-function cloneRepository(dir, url, next) {
+function cloneRepository(dir, url, ciMode = false, next) {
+  if(ciMode) {
+    url = sshToHttps(url);
+  }
+  outputWriter.printError("cloning "+url);
+  
   var proc = child.spawn('git', ['clone', url, dir], {env: env});
   proc.on('error', function (error) {
     next(error);
@@ -1279,9 +1288,9 @@ h5p.get = function (libraries, next) {
 /**
  * Clone the next library in the collection.
  */
-h5p.clone = function (next) {
+h5p.clone = function (ciMode = false, next) {
   for (var lib in collection) {
-    cloneRepository(lib, collection[lib].repository, next);
+    cloneRepository(lib, collection[lib].repository, ciMode, next);
     delete collection[lib];
     return lib;
   }

--- a/lib/h5p.js
+++ b/lib/h5p.js
@@ -143,8 +143,8 @@ function sshToHttps(url){
 /**
  * Clone repo at given url into given dir.
  */
-function cloneRepository(dir, url, ciMode = false, next) {
-  if(ciMode) {
+function cloneRepository(dir, url, fetchWithHttps = false, next) {
+  if(fetchWithHttps) {
     url = sshToHttps(url);
   }
   outputWriter.printError("cloning "+url);
@@ -1288,9 +1288,9 @@ h5p.get = function (libraries, next) {
 /**
  * Clone the next library in the collection.
  */
-h5p.clone = function (ciMode = false, next) {
+h5p.clone = function (fetchWithHttps = false, next) {
   for (var lib in collection) {
-    cloneRepository(lib, collection[lib].repository, ciMode, next);
+    cloneRepository(lib, collection[lib].repository, fetchWithHttps, next);
     delete collection[lib];
     return lib;
   }


### PR DESCRIPTION
SSH github urls are challenging  to use wheb using H5P CLI inside CI or Docker builds. This pull requests adds an option to the "get" command in H5P CLI that translates repository links when in "ci mode".