### PR TITLE
Fix not loading h5p-core-button.css

### DIFF
--- a/assets/templates/view.html
+++ b/assets/templates/view.html
@@ -53,6 +53,7 @@
       styles: [
         "/{libraries}/h5p-php-library/styles/h5p.css",
         "/{libraries}/h5p-php-library/styles/h5p-confirmation-dialog.css",
+        "/{libraries}/h5p-php-library/styles/h5p-core-button.css",
         "/{libraries}/h5p-php-library/styles/h5p-tooltip.css"
       ]
     },


### PR DESCRIPTION
When merged in, will load `h5p-core-button.css` in the view.

Currently, the stylesheet `h5p-core-button.css` is not loaded in the view. It's required to properly style the buttons in an instance of H5P core's `ConfirmationDialog`, for instance.