### PR TITLE
Add application specific style for editor iframe

### DIFF
--- a/assets/styles/editor.css
+++ b/assets/styles/editor.css
@@ -1,0 +1,12 @@
+.h5peditor-form {
+  background: #fcfcfc;
+  border: 1px solid #d0d0d1;
+  position: relative;
+}
+.h5peditor-form>.common,
+.h5peditor-form>.field,
+.h5peditor-form>.tree {
+  margin: 20px auto;
+  max-width: 918px;
+  padding: 0 20px;
+}

--- a/assets/templates/edit.html
+++ b/assets/templates/edit.html
@@ -48,6 +48,7 @@
       nodeVersionId: "{folder}",
       assets: {
         css: [
+          "/{assets}/styles/editor.css",
           "/{libraries}/h5p-php-library/styles/h5p.css",
           "/{libraries}/h5p-php-library/styles/h5p-confirmation-dialog.css",
           "/{libraries}/h5p-php-library/styles/h5p-core-button.css",


### PR DESCRIPTION
When merged in, will load `editor.css` in the editor to style the editor form as on other H5P Integrations in order to keep the visual appearance consistent.

Currently, some commonly used extra styles for the editor form that are defined by the H5P Integration (such as H5P.com, Drupal, etc.) are not used. There are no editor specific styles that are added to the editor iframe. That makes the editor look a little weird, e.g. not having a margin.