### PR TITLE
HFP-3901 Add missing fileIcon definition

### DIFF
--- a/assets/templates/edit.html
+++ b/assets/templates/edit.html
@@ -41,6 +41,11 @@
       metadataSemantics: {metadataSemantics},
       libraryUrl: "/{libraries}/h5p-editor-php-library/",
       nodeVersionId: "{folder}",
+      fileIcon: {
+        path: "/{libraries}/h5p-editor-php-library/images/binary-file.png",
+        width: 50,
+        height:50
+      },
       assets: {
         css: [
           "/{assets}/styles/editor.css",


### PR DESCRIPTION
When merged in, will add the `fileIcon` definition that the H5PEditor core expects.

Currently, the `H5PIntegration` setup for the H5PEditor core expects a default `fileIcon` to be set that the file widget uses for binary files. The editor will crash if a binary file is uploaded without it.

I'd technically expect https://github.com/h5p/h5p-editor-php-library/pull/209 this to be the fix, in particular as no H5P integration so far provides a custom icon but always uses the default found in H5P core. But nothing seems to ever happen (those tiny non-brainer pull-requests were simply handled and merged back in the days), I am getting annoyed by all the quirks I have to live with here, so maybe on this repo the success rate of being recognized is higher.