### PR TITLE
HFP-3904 Add stylistic tweaks and nit-picking

### DIFF
--- a/assets/docs/commands.md
+++ b/assets/docs/commands.md
@@ -1,34 +1,34 @@
-• `h5p help` prints this help page.  
-`h5p help <command>` prints the help entry for that `<command>`.  
+• `h5p help` prints this help page.
+`h5p help <command>` prints the help entry for that `<command>`.
 
-• `h5p utils help` prints a list of utility commands.  
-Each utility command can then be run via `h5p utils <cmd> [<args>...]`.  
-Run `h5p utils help <cmd>` for a detailed help entry for each utility `<cmd>`.  
+• `h5p utils help` prints a list of utility commands.
+Each utility command can then be run via `h5p utils <cmd> [<args>...]`.
+Run `h5p utils help <cmd>` for a detailed help entry for each utility `<cmd>`.
 
-• `h5p core` installs the core h5p libraries.  
-These are required to view and edit h5p content types.  
+• `h5p core` installs the core H5P libraries.
+These are required to view and edit H5P content types.
 
-• `h5p list [machineName] [ignoreCache]` lists the current h5p libraries.  
-Use `1` for `[machineName]` to list the machine name instead of the default repo name.  
-Use `1` for `[ignoreCache]` to recreate the local registry.  
-The output format is `<library> (<org>)`.  
+• `h5p list [machineName] [ignoreCache]` lists the current H5P libraries.
+Use `1` for `[machineName]` to list the machine name instead of the default repo name.
+Use `1` for `[ignoreCache]` to recreate the local registry.
+The output format is `<library> (<org>)`.
 
-• `h5p tags <org> <library> <mainBranch>` lists current library versions.  
-The `<org>` for a library is mentioned in the `list` command output.  
-`<mainBranch>` is the main branch of the repository. Default is `master`.  
+• `h5p tags <org> <library> <mainBranch>` lists current library versions.
+The `<org>` for a library is mentioned in the `list` command output.
+`<mainBranch>` is the main branch of the repository. Default is `master`.
 
-• `h5p deps <library> <mode> [saveToCache] [version] [folder]` computes dependencies for an h5p library.  
-Use `view` or `edit` for `<mode>` to generate dependencies for those cases.  
-Specify `1` for `[saveToCache]` to save the result in the cache folder. Default is `0`.  
-Specify a `[version]` to compute deps for that version. Default is `master`. Use the `tags` command to list versions for a library.  
-Specify a `[folder]` to compute deps based on the library from `libraries/[folder]` folder. Default is `""`.  
+• `h5p deps <library> <mode> [saveToCache] [version] [folder]` computes dependencies for an H5P library.
+Use `view` or `edit` for `<mode>` to generate dependencies for those cases.
+Specify `1` for `[saveToCache]` to save the result in the cache folder. Default is `0`.
+Specify a `[version]` to compute deps for that version. Default is `master`. Use the `tags` command to list versions for a library.
+Specify a `[folder]` to compute deps based on the library from `libraries/[folder]` folder. Default is `""`.
 
-• `h5p use <library> <folder>` computes view & edit dependencies for a `<library>` using the provided `libraries/<folder>` as the main library. A local library registry entry will also be created if the library is missing from the local registry.  
+• `h5p use <library> <folder>` computes view & edit dependencies for a `<library>` using the provided `libraries/<folder>` as the main library. A local library registry entry will also be created if the library is missing from the local registry.
 Library dependencies need to be present in the `libraries` folder.
 
-• `h5p register <gitUrl>` or `h5p register <entry.json>` to add or update entries in the local registry.  
-`<gitUrl>` is something like `git@github.com:h5p/h5p-accordion.git` or `https://github.com/h5p/h5p-accordion`.  
-If specified, the `<entry.json>` file needs to be created. Below is an example.  
+• `h5p register <gitUrl>` or `h5p register <entry.json>` to add or update entries in the local registry.
+`<gitUrl>` is something like `git@github.com:h5p/h5p-accordion.git` or `https://github.com/h5p/h5p-accordion`.
+If specified, the `<entry.json>` file needs to be created. Below is an example.
 You can use this command to update existing registry entries.
 ```
 {
@@ -48,29 +48,29 @@ You can use this command to update existing registry entries.
 }
 ```
 
-• `h5p clone <library> <mode> [useCache]` clones the library and its dependencies in the libraries folder.  
-Use `view` or `edit` for `<mode>`.  
-`[useCache]` can be `1` if you want it to use the cached deps.  
+• `h5p clone <library> <mode> [useCache]` clones the library and its dependencies in the libraries folder.
+Use `view` or `edit` for `<mode>`.
+`[useCache]` can be `1` if you want it to use the cached deps.
 
-• `h5p install <library> <mode> [useCache]` downloads the library and its dependencies in the libraries folder.  
-Use `view` or `edit` for `<mode>`.  
-`[useCache]` can be `1` if you want it to use the cached deps.  
+• `h5p install <library> <mode> [useCache]` downloads the library and its dependencies in the libraries folder.
+Use `view` or `edit` for `<mode>`.
+`[useCache]` can be `1` if you want it to use the cached deps.
 
-• `h5p setup <library|repoUrl> [version] [download]` sets up a library and its dependencies.  
-`<repoUrl>` is a github repository url. Running the command in this format will also update the library in the local registry. This is useful for unregistered libraries.  
-For example, `h5p setup git@github.com:h5p/h5p-accordion.git` installs the "h5p-accordion" library and its dependencies. It also updates its entry in the local library registry.  
+• `h5p setup <library|repoUrl> [version] [download]` sets up a library and its dependencies.
+`<repoUrl>` is a github repository url. Running the command in this format will also update the library in the local registry. This is useful for unregistered libraries.
+For example, `h5p setup git@github.com:h5p/h5p-accordion.git` installs the "h5p-accordion" library and its dependencies. It also updates its entry in the local library registry.
 You can optionally specify a library `[version]`. To view current versions for a library use the `tags` command.
-Using `1` for the `[download]` parameter will download the libraries instead of cloning them as git repos.  
-Set the `H5P_NO_UPDATES` environment variable to `1` to skip updating libraries and speed up the setup process.  
-Set the `H5P_SSH_CLONE` environment variable to `1` so that ssh urls are used when cloning private repositories. This is useful for cloning private repos and for when you want to commit from the `libraries/<library>` folder.  
+Using `1` for the `[download]` parameter will download the libraries instead of cloning them as git repos.
+Set the `H5P_NO_UPDATES` environment variable to `1` to skip updating libraries and speed up the setup process.
+Set the `H5P_SSH_CLONE` environment variable to `1` so that ssh urls are used when cloning private repositories. This is useful for cloning private repos and for when you want to commit from the `libraries/<library>` folder.
 > [!IMPORTANT]
-> If no `[version]` is specified master branches will be used.  
+> If no `[version]` is specified master branches will be used.
 
-• `h5p missing <library>` will compute the unregistered dependencies for a library.  
-The library itself has to exist in the local library registry.  
+• `h5p missing <library>` will compute the unregistered dependencies for a library.
+The library itself has to exist in the local library registry.
 
-• `h5p verify <h5p-repo-name>` to check the status of the setup for a given library.  
-Running `h5p verify h5p-accordion` should return something like below if the library was properly set up.  
+• `h5p verify <h5p-repo-name>` to check the status of the setup for a given library.
+Running `h5p verify h5p-accordion` should return something like below if the library was properly set up.
 ```
 {
   registry: true, // library found in registry
@@ -84,21 +84,21 @@ Running `h5p verify h5p-accordion` should return something like below if the lib
 }
 ```
 
-• `h5p server [port]` starts the dev server.  
-`[port]` is an optional port number. Default is 8080.  
-Once the dev server is started you can use your browser to view, edit, delete, import, export and create new content types.  
+• `h5p server [port]` starts the dev server.
+`[port]` is an optional port number. Default is 8080.
+Once the dev server is started you can use your browser to view, edit, delete, import, export and create new content types.
 
-• `h5p export <library> <folder>` will export the `<library>` content type from the `content/<folder>` folder.  
-An example here is `h5p export h5p-agamotto agamotto-test` which will export the `h5p-agamotto` content type located in the `content/agamotto-test` folder.  
-Make sure that the library's dependency lists are cached and that the dependencies are installed.  
-Once finished, the export command outputs the location of the resulting file.  
+• `h5p export <library> <folder>` will export the `<library>` content type from the `content/<folder>` folder.
+An example here is `h5p export h5p-agamotto agamotto-test` which will export the `h5p-agamotto` content type located in the `content/agamotto-test` folder.
+Make sure that the library's dependency lists are cached and that the dependencies are installed.
+Once finished, the export command outputs the location of the resulting file.
 
-• `h5p import <folder> <h5p_archive_file_path>` will import the archived .h5p `<h5p_archive_file_path>` content type into the `content/<folder>` folder.  
-An example here is `h5p import agamotto-test ~/Downloads/agamotto_test.h5p` which will import the `~/Downloads/agamotto_test.h5p` archived .h5p file into the `content/agamotto-test` folder.  
-Once finished, the import command outputs the location of the resulting content type folder.  
+• `h5p import <folder> <h5p_archive_file_path>` will import the archived .h5p `<h5p_archive_file_path>` content type into the `content/<folder>` folder.
+An example here is `h5p import agamotto-test ~/Downloads/agamotto_test.h5p` which will import the `~/Downloads/agamotto_test.h5p` archived .h5p file into the `content/agamotto-test` folder.
+Once finished, the import command outputs the location of the resulting content type folder.
 
- When viewing content types they are automatically upgraded to the version of the currently used main library.  
- When viewing content types you can create and switch between resume sessions. A resume session allows you to save the state of the content type that supports it so that it will be the same on reload.  
- You can create a new session by clicking on the "new session" button and entering a new name for it.  
- To switch between existing sessions simply choose the one you want from the dropdown. Choose the "null" session to not save states.  
- To stop auto reloading the view page on library file changes set `files.watch` to `false` in `config.json`.  
+ When viewing content types they are automatically upgraded to the version of the currently used main library.
+ When viewing content types you can create and switch between resume sessions. A resume session allows you to save the state of the content type that supports it so that it will be the same on reload.
+ You can create a new session by clicking on the "new session" button and entering a new name for it.
+ To switch between existing sessions simply choose the one you want from the dropdown. Choose the "null" session to not save states.
+ To stop auto reloading the view page on library file changes set `files.watch` to `false` in `config.json`.

--- a/assets/docs/commands.md
+++ b/assets/docs/commands.md
@@ -1,34 +1,34 @@
-• `h5p help` prints this help page.
-`h5p help <command>` prints the help entry for that `<command>`.
+• `h5p help` prints this help page.  
+`h5p help <command>` prints the help entry for that `<command>`.  
 
-• `h5p utils help` prints a list of utility commands.
-Each utility command can then be run via `h5p utils <cmd> [<args>...]`.
-Run `h5p utils help <cmd>` for a detailed help entry for each utility `<cmd>`.
+• `h5p utils help` prints a list of utility commands.  
+Each utility command can then be run via `h5p utils <cmd> [<args>...]`.  
+Run `h5p utils help <cmd>` for a detailed help entry for each utility `<cmd>`.  
 
-• `h5p core` installs the core H5P libraries.
-These are required to view and edit H5P content types.
+• `h5p core` installs the core H5P libraries.  
+These are required to view and edit H5P content types.  
 
-• `h5p list [machineName] [ignoreCache]` lists the current H5P libraries.
-Use `1` for `[machineName]` to list the machine name instead of the default repo name.
-Use `1` for `[ignoreCache]` to recreate the local registry.
-The output format is `<library> (<org>)`.
+• `h5p list [machineName] [ignoreCache]` lists the current H5P libraries.  
+Use `1` for `[machineName]` to list the machine name instead of the default repo name.  
+Use `1` for `[ignoreCache]` to recreate the local registry.  
+The output format is `<library> (<org>)`.  
 
-• `h5p tags <org> <library> <mainBranch>` lists current library versions.
-The `<org>` for a library is mentioned in the `list` command output.
-`<mainBranch>` is the main branch of the repository. Default is `master`.
+• `h5p tags <org> <library> <mainBranch>` lists current library versions.  
+The `<org>` for a library is mentioned in the `list` command output.  
+`<mainBranch>` is the main branch of the repository. Default is `master`.  
 
-• `h5p deps <library> <mode> [saveToCache] [version] [folder]` computes dependencies for an H5P library.
-Use `view` or `edit` for `<mode>` to generate dependencies for those cases.
-Specify `1` for `[saveToCache]` to save the result in the cache folder. Default is `0`.
-Specify a `[version]` to compute deps for that version. Default is `master`. Use the `tags` command to list versions for a library.
-Specify a `[folder]` to compute deps based on the library from `libraries/[folder]` folder. Default is `""`.
+• `h5p deps <library> <mode> [saveToCache] [version] [folder]` computes dependencies for an H5P library.  
+Use `view` or `edit` for `<mode>` to generate dependencies for those cases.  
+Specify `1` for `[saveToCache]` to save the result in the cache folder. Default is `0`.  
+Specify a `[version]` to compute deps for that version. Default is `master`. Use the `tags` command to list versions for a library.  
+Specify a `[folder]` to compute deps based on the library from `libraries/[folder]` folder. Default is `""`.  
 
-• `h5p use <library> <folder>` computes view & edit dependencies for a `<library>` using the provided `libraries/<folder>` as the main library. A local library registry entry will also be created if the library is missing from the local registry.
+• `h5p use <library> <folder>` computes view & edit dependencies for a `<library>` using the provided `libraries/<folder>` as the main library. A local library registry entry will also be created if the library is missing from the local registry.  
 Library dependencies need to be present in the `libraries` folder.
 
-• `h5p register <gitUrl>` or `h5p register <entry.json>` to add or update entries in the local registry.
-`<gitUrl>` is something like `git@github.com:h5p/h5p-accordion.git` or `https://github.com/h5p/h5p-accordion`.
-If specified, the `<entry.json>` file needs to be created. Below is an example.
+• `h5p register <gitUrl>` or `h5p register <entry.json>` to add or update entries in the local registry.  
+`<gitUrl>` is something like `git@github.com:h5p/h5p-accordion.git` or `https://github.com/h5p/h5p-accordion`.  
+If specified, the `<entry.json>` file needs to be created. Below is an example.  
 You can use this command to update existing registry entries.
 ```
 {
@@ -48,29 +48,29 @@ You can use this command to update existing registry entries.
 }
 ```
 
-• `h5p clone <library> <mode> [useCache]` clones the library and its dependencies in the libraries folder.
-Use `view` or `edit` for `<mode>`.
-`[useCache]` can be `1` if you want it to use the cached deps.
+• `h5p clone <library> <mode> [useCache]` clones the library and its dependencies in the libraries folder.  
+Use `view` or `edit` for `<mode>`.  
+`[useCache]` can be `1` if you want it to use the cached deps.  
 
-• `h5p install <library> <mode> [useCache]` downloads the library and its dependencies in the libraries folder.
-Use `view` or `edit` for `<mode>`.
-`[useCache]` can be `1` if you want it to use the cached deps.
+• `h5p install <library> <mode> [useCache]` downloads the library and its dependencies in the libraries folder.  
+Use `view` or `edit` for `<mode>`.  
+`[useCache]` can be `1` if you want it to use the cached deps.  
 
-• `h5p setup <library|repoUrl> [version] [download]` sets up a library and its dependencies.
-`<repoUrl>` is a github repository url. Running the command in this format will also update the library in the local registry. This is useful for unregistered libraries.
-For example, `h5p setup git@github.com:h5p/h5p-accordion.git` installs the "h5p-accordion" library and its dependencies. It also updates its entry in the local library registry.
+• `h5p setup <library|repoUrl> [version] [download]` sets up a library and its dependencies.  
+`<repoUrl>` is a github repository url. Running the command in this format will also update the library in the local registry. This is useful for unregistered libraries.  
+For example, `h5p setup git@github.com:h5p/h5p-accordion.git` installs the "h5p-accordion" library and its dependencies. It also updates its entry in the local library registry.  
 You can optionally specify a library `[version]`. To view current versions for a library use the `tags` command.
-Using `1` for the `[download]` parameter will download the libraries instead of cloning them as git repos.
-Set the `H5P_NO_UPDATES` environment variable to `1` to skip updating libraries and speed up the setup process.
-Set the `H5P_SSH_CLONE` environment variable to `1` so that ssh urls are used when cloning private repositories. This is useful for cloning private repos and for when you want to commit from the `libraries/<library>` folder.
+Using `1` for the `[download]` parameter will download the libraries instead of cloning them as git repos.  
+Set the `H5P_NO_UPDATES` environment variable to `1` to skip updating libraries and speed up the setup process.  
+Set the `H5P_SSH_CLONE` environment variable to `1` so that ssh urls are used when cloning private repositories. This is useful for cloning private repos and for when you want to commit from the `libraries/<library>` folder.  
 > [!IMPORTANT]
-> If no `[version]` is specified master branches will be used.
+> If no `[version]` is specified master branches will be used.  
 
-• `h5p missing <library>` will compute the unregistered dependencies for a library.
-The library itself has to exist in the local library registry.
+• `h5p missing <library>` will compute the unregistered dependencies for a library.  
+The library itself has to exist in the local library registry.  
 
-• `h5p verify <h5p-repo-name>` to check the status of the setup for a given library.
-Running `h5p verify h5p-accordion` should return something like below if the library was properly set up.
+• `h5p verify <h5p-repo-name>` to check the status of the setup for a given library.  
+Running `h5p verify h5p-accordion` should return something like below if the library was properly set up.  
 ```
 {
   registry: true, // library found in registry
@@ -84,21 +84,21 @@ Running `h5p verify h5p-accordion` should return something like below if the lib
 }
 ```
 
-• `h5p server [port]` starts the dev server.
-`[port]` is an optional port number. Default is 8080.
-Once the dev server is started you can use your browser to view, edit, delete, import, export and create new content types.
+• `h5p server [port]` starts the dev server.  
+`[port]` is an optional port number. Default is 8080.  
+Once the dev server is started you can use your browser to view, edit, delete, import, export and create new content types.  
 
-• `h5p export <library> <folder>` will export the `<library>` content type from the `content/<folder>` folder.
-An example here is `h5p export h5p-agamotto agamotto-test` which will export the `h5p-agamotto` content type located in the `content/agamotto-test` folder.
-Make sure that the library's dependency lists are cached and that the dependencies are installed.
-Once finished, the export command outputs the location of the resulting file.
+• `h5p export <library> <folder>` will export the `<library>` content type from the `content/<folder>` folder.  
+An example here is `h5p export h5p-agamotto agamotto-test` which will export the `h5p-agamotto` content type located in the `content/agamotto-test` folder.  
+Make sure that the library's dependency lists are cached and that the dependencies are installed.  
+Once finished, the export command outputs the location of the resulting file.  
 
-• `h5p import <folder> <h5p_archive_file_path>` will import the archived .h5p `<h5p_archive_file_path>` content type into the `content/<folder>` folder.
-An example here is `h5p import agamotto-test ~/Downloads/agamotto_test.h5p` which will import the `~/Downloads/agamotto_test.h5p` archived .h5p file into the `content/agamotto-test` folder.
-Once finished, the import command outputs the location of the resulting content type folder.
+• `h5p import <folder> <h5p_archive_file_path>` will import the archived .h5p `<h5p_archive_file_path>` content type into the `content/<folder>` folder.  
+An example here is `h5p import agamotto-test ~/Downloads/agamotto_test.h5p` which will import the `~/Downloads/agamotto_test.h5p` archived .h5p file into the `content/agamotto-test` folder.  
+Once finished, the import command outputs the location of the resulting content type folder.  
 
- When viewing content types they are automatically upgraded to the version of the currently used main library.
- When viewing content types you can create and switch between resume sessions. A resume session allows you to save the state of the content type that supports it so that it will be the same on reload.
- You can create a new session by clicking on the "new session" button and entering a new name for it.
- To switch between existing sessions simply choose the one you want from the dropdown. Choose the "null" session to not save states.
- To stop auto reloading the view page on library file changes set `files.watch` to `false` in `config.json`.
+ When viewing content types they are automatically upgraded to the version of the currently used main library.  
+ When viewing content types you can create and switch between resume sessions. A resume session allows you to save the state of the content type that supports it so that it will be the same on reload.  
+ You can create a new session by clicking on the "new session" button and entering a new name for it.  
+ To switch between existing sessions simply choose the one you want from the dropdown. Choose the "null" session to not save states.  
+ To stop auto reloading the view page on library file changes set `files.watch` to `false` in `config.json`.  

--- a/assets/docs/setup.md
+++ b/assets/docs/setup.md
@@ -1,58 +1,58 @@
 # Folder structure
 
-Running commands listed in [commands.md](commands.md) results in the creation of five folders. The folders are created in the current working directory (the folder where you ran the command).  
-`cache` holds computed dependency lists for the libraries that have been set up.  
-`content` holds actual content types and their assets.  
-`libraries` holds the libraries that have been set up.  
-`temp` holds local copies of git repositories that are used when computing dependencies.  
-`uploads` is a temporary location used by the import and export commands.  
+Running commands listed in [commands.md](commands.md) results in the creation of five folders. The folders are created in the current working directory (the folder where you ran the command).
+- `cache` holds computed dependency lists for the libraries that have been set up.
+- `content` holds actual content types and their assets.
+- `libraries` holds the libraries that have been set up.
+- `temp` holds local copies of git repositories that are used when computing dependencies.
+- `uploads` is a temporary location used by the import and export commands.
 
 > [!IMPORTANT]
-> Make sure to delete the `temp` folder when updating to the latest version of a library that has new or updated dependencies so that fresh git repository copies are cloned.  
+> Make sure to delete the `temp` folder when updating to the latest version of a library that has new or updated dependencies so that fresh git repository copies are cloned.
 
 # Setup a local library
 
-To use your own local library create a folder for it in the `libraries` directory. The library folder name format is `<h5pLibraryName>-<majorVersion>.<minorVersion>`.  
-Then run `h5p use <library> <folder>`.  
-`<library>` is something like `h5p-greeting-card`.  
-`<folder>` is something like `H5P.GreetingCard-1.0`.  
+To use your own local library create a folder for it in the `libraries` directory. The library folder name format is `<h5pLibraryName>-<majorVersion>.<minorVersion>`.
+Then run `h5p use <library> <folder>`.
+`<library>` is something like `h5p-greeting-card`.
+`<folder>` is something like `H5P.GreetingCard-1.0`.
 An example for this is
 ```
 h5p use h5p-greeting-card H5P.GreetingCard-1.0
 ```
-It will setup the `h5p-greeting-card` library located in the `libraries/H5P.GreetingCard-1.0` directory.  
-Its dependencies need to be present in the `libraries` folder. Ootherwise they need to be set up separately.  
-Please note that, should the dependencies change (including the optional ones in semantics.json), you will have to run this command again in order to regenerate the cached dependency lists.  
-A library development tutorial can be found [here](https://h5p.org/library-development).  
+It will setup the `h5p-greeting-card` library located in the `libraries/H5P.GreetingCard-1.0` directory.
+Its dependencies need to be present in the `libraries` folder. Otherwise they need to be set up separately.
+Please note that, should the dependencies change (including the optional ones in semantics.json), you will have to run this command again in order to regenerate the cached dependency lists.
+Please [find a library development tutorial](https://h5p.org/library-development) for details on that topic.
 
 # Setup a library from github
 
-Libraries that can be automatically installed are stored in the local library registry. The registry is a json file located at `cache/libraryRegistry.json`.  
-Running `h5p setup <library>` may return the `unregistered library` error. This means that the local library registry is missing this library. We have to find its repository url and register it.  
-As an example, run `h5p register https://github.com/otacke/h5p-game-map` to register the `h5p-game-map` library in the local registry.  
-Run `h5p missing h5p-game-map` to list the unregistered dependencies for `h5p-game-map`. Then find their repository urls and register them.  
+Libraries that can be automatically installed are stored in the local library registry. The registry is a json file located at `cache/libraryRegistry.json`.
+Running `h5p setup <library>` may return the `unregistered library` error. This means that the local library registry is missing this library. We have to find its repository url and register it.
+As an example, run `h5p register https://github.com/otacke/h5p-game-map` to register the `h5p-game-map` library in the local registry.
+Run `h5p missing h5p-game-map` to list the unregistered dependencies for `h5p-game-map`. Then find their repository urls and register them.
 ```
 h5p register https://github.com/otacke/h5p-editor-game-map
 h5p register https://github.com/otacke/h5p-combination-lock
 h5p register https://github.com/otacke/h5p-tabs
 h5p register https://github.com/otacke/h5p-transcript
 ```
-Run `h5p missing h5p-game-map` again to list any unregistered dependencies for the newly registered ones. And register them.  
+Run `h5p missing h5p-game-map` again to list any unregistered dependencies for the newly registered ones. And register them.
 ```
 h5p register https://github.com/otacke/h5p-editor-tabs
 h5p register https://github.com/otacke/h5p-transcript-library
 ```
-Run `h5p missing h5p-game-map` again to make sure there are no other unregistered dependencies.  
-Finally, run `h5p setup h5p-game-map` to install the library and its dependencies.  
-You can use the `git@github.com:otacke/h5p-game-map.git` url format when dealing with private repositories.  
+Run `h5p missing h5p-game-map` again to make sure there are no other unregistered dependencies.
+Finally, run `h5p setup h5p-game-map` to install the library and its dependencies.
+You can use the `git@github.com:otacke/h5p-game-map.git` url format when dealing with private repositories.
 
 # GIT and your SSH-AGENT
 
-If you have to setup libraries from private repositories or if you encounter the `Permission denied (publickey)` error make sure you add your public ssh key to your local ssh agent.  
-It's as easy as running the two commands below.  
+If you have to setup libraries from private repositories or if you encounter the `Permission denied (publickey)` error make sure you add your public ssh key to your local ssh agent.
+It's as easy as running the two commands below.
 ```
 eval `ssh-agent -t 8h`
 ssh-add
 ```
-All git related commands should now work in the current session for at least 8h. Feel free to change the duration to better suit your needs. :)  
-Here are some guides on how to add an ssh key to the ssh agent on [Linux](https://docs.github.com/en/enterprise-cloud@latest/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent), [Mac](https://docs.github.com/en/enterprise-cloud@latest/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent?platform=mac#adding-your-ssh-key-to-the-ssh-agent), [Windows](https://docs.github.com/en/enterprise-cloud@latest/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent?platform=windows#adding-your-ssh-key-to-the-ssh-agent).  
+All git related commands should now work in the current session for at least 8h. Feel free to change the duration to better suit your needs. :)
+Here are some guides on how to add an ssh key to the ssh agent on [Linux](https://docs.github.com/en/enterprise-cloud@latest/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent), [Mac](https://docs.github.com/en/enterprise-cloud@latest/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent?platform=mac#adding-your-ssh-key-to-the-ssh-agent), [Windows](https://docs.github.com/en/enterprise-cloud@latest/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent?platform=windows#adding-your-ssh-key-to-the-ssh-agent).

--- a/assets/docs/setup.md
+++ b/assets/docs/setup.md
@@ -1,58 +1,58 @@
 # Folder structure
 
-Running commands listed in [commands.md](commands.md) results in the creation of five folders. The folders are created in the current working directory (the folder where you ran the command).
-- `cache` holds computed dependency lists for the libraries that have been set up.
-- `content` holds actual content types and their assets.
-- `libraries` holds the libraries that have been set up.
-- `temp` holds local copies of git repositories that are used when computing dependencies.
-- `uploads` is a temporary location used by the import and export commands.
+Running commands listed in [commands.md](commands.md) results in the creation of five folders. The folders are created in the current working directory (the folder where you ran the command).  
+- `cache` holds computed dependency lists for the libraries that have been set up.  
+- `content` holds actual content types and their assets.  
+- `libraries` holds the libraries that have been set up.  
+- `temp` holds local copies of git repositories that are used when computing dependencies.  
+- `uploads` is a temporary location used by the import and export commands.  
 
 > [!IMPORTANT]
-> Make sure to delete the `temp` folder when updating to the latest version of a library that has new or updated dependencies so that fresh git repository copies are cloned.
+> Make sure to delete the `temp` folder when updating to the latest version of a library that has new or updated dependencies so that fresh git repository copies are cloned.  
 
 # Setup a local library
 
-To use your own local library create a folder for it in the `libraries` directory. The library folder name format is `<h5pLibraryName>-<majorVersion>.<minorVersion>`.
-Then run `h5p use <library> <folder>`.
-`<library>` is something like `h5p-greeting-card`.
-`<folder>` is something like `H5P.GreetingCard-1.0`.
+To use your own local library create a folder for it in the `libraries` directory. The library folder name format is `<h5pLibraryName>-<majorVersion>.<minorVersion>`.  
+Then run `h5p use <library> <folder>`.  
+`<library>` is something like `h5p-greeting-card`.  
+`<folder>` is something like `H5P.GreetingCard-1.0`.  
 An example for this is
 ```
 h5p use h5p-greeting-card H5P.GreetingCard-1.0
 ```
-It will setup the `h5p-greeting-card` library located in the `libraries/H5P.GreetingCard-1.0` directory.
-Its dependencies need to be present in the `libraries` folder. Otherwise they need to be set up separately.
-Please note that, should the dependencies change (including the optional ones in semantics.json), you will have to run this command again in order to regenerate the cached dependency lists.
-Please [find a library development tutorial](https://h5p.org/library-development) for details on that topic.
+It will setup the `h5p-greeting-card` library located in the `libraries/H5P.GreetingCard-1.0` directory.  
+Its dependencies need to be present in the `libraries` folder. Otherwise they need to be set up separately.  
+Please note that, should the dependencies change (including the optional ones in semantics.json), you will have to run this command again in order to regenerate the cached dependency lists.  
+Please [find a library development tutorial](https://h5p.org/library-development) for details on that topic.  
 
 # Setup a library from github
 
-Libraries that can be automatically installed are stored in the local library registry. The registry is a json file located at `cache/libraryRegistry.json`.
-Running `h5p setup <library>` may return the `unregistered library` error. This means that the local library registry is missing this library. We have to find its repository url and register it.
-As an example, run `h5p register https://github.com/otacke/h5p-game-map` to register the `h5p-game-map` library in the local registry.
-Run `h5p missing h5p-game-map` to list the unregistered dependencies for `h5p-game-map`. Then find their repository urls and register them.
+Libraries that can be automatically installed are stored in the local library registry. The registry is a json file located at `cache/libraryRegistry.json`.  
+Running `h5p setup <library>` may return the `unregistered library` error. This means that the local library registry is missing this library. We have to find its repository url and register it.  
+As an example, run `h5p register https://github.com/otacke/h5p-game-map` to register the `h5p-game-map` library in the local registry.  
+Run `h5p missing h5p-game-map` to list the unregistered dependencies for `h5p-game-map`. Then find their repository urls and register them.  
 ```
 h5p register https://github.com/otacke/h5p-editor-game-map
 h5p register https://github.com/otacke/h5p-combination-lock
 h5p register https://github.com/otacke/h5p-tabs
 h5p register https://github.com/otacke/h5p-transcript
 ```
-Run `h5p missing h5p-game-map` again to list any unregistered dependencies for the newly registered ones. And register them.
+Run `h5p missing h5p-game-map` again to list any unregistered dependencies for the newly registered ones. And register them.  
 ```
 h5p register https://github.com/otacke/h5p-editor-tabs
 h5p register https://github.com/otacke/h5p-transcript-library
 ```
-Run `h5p missing h5p-game-map` again to make sure there are no other unregistered dependencies.
-Finally, run `h5p setup h5p-game-map` to install the library and its dependencies.
-You can use the `git@github.com:otacke/h5p-game-map.git` url format when dealing with private repositories.
+Run `h5p missing h5p-game-map` again to make sure there are no other unregistered dependencies.  
+Finally, run `h5p setup h5p-game-map` to install the library and its dependencies.  
+You can use the `git@github.com:otacke/h5p-game-map.git` url format when dealing with private repositories.  
 
 # GIT and your SSH-AGENT
 
-If you have to setup libraries from private repositories or if you encounter the `Permission denied (publickey)` error make sure you add your public ssh key to your local ssh agent.
-It's as easy as running the two commands below.
+If you have to setup libraries from private repositories or if you encounter the `Permission denied (publickey)` error make sure you add your public ssh key to your local ssh agent.  
+It's as easy as running the two commands below.  
 ```
 eval `ssh-agent -t 8h`
 ssh-add
 ```
-All git related commands should now work in the current session for at least 8h. Feel free to change the duration to better suit your needs. :)
-Here are some guides on how to add an ssh key to the ssh agent on [Linux](https://docs.github.com/en/enterprise-cloud@latest/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent), [Mac](https://docs.github.com/en/enterprise-cloud@latest/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent?platform=mac#adding-your-ssh-key-to-the-ssh-agent), [Windows](https://docs.github.com/en/enterprise-cloud@latest/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent?platform=windows#adding-your-ssh-key-to-the-ssh-agent).
+All git related commands should now work in the current session for at least 8h. Feel free to change the duration to better suit your needs. :)  
+Here are some guides on how to add an ssh key to the ssh agent on [Linux](https://docs.github.com/en/enterprise-cloud@latest/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent), [Mac](https://docs.github.com/en/enterprise-cloud@latest/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent?platform=mac#adding-your-ssh-key-to-the-ssh-agent), [Windows](https://docs.github.com/en/enterprise-cloud@latest/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent?platform=windows#adding-your-ssh-key-to-the-ssh-agent).  

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
-An H5P toolkit for running, editing and developing H5P content types.
+An h5p toolkit for running, editing and developing h5p content types.  
 
-Make sure you have [git](https://git-scm.com/downloads), [NodeJS](https://nodejs.org/en/download/current) and [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) (usually included in NodeJS) installed.
-Some of the commands listed here are Linux & MacOS specific. On Windows it’s recommended that you run them inside [git bash](https://git-scm.com/download/win).
+Make sure you have [git](https://git-scm.com/downloads), [NodeJS](https://nodejs.org/en/download/current) and [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) (usually included in NodeJS) installed.  
+Some of the commands listed here are Linux & MacOS specific. On Windows it’s recommended that you run them inside [git bash](https://git-scm.com/download/win).  
 
 # INSTALLATION
 
@@ -18,17 +18,17 @@ npm install
 cd ..
 npm install -g ./h5p-cli
 ```
-You can now use `h5p` as a global command.
+You can now use `h5p` as a global command.  
 
 ![installation gif](assets/docs/install.gif)
 
 # QUICK START GUIDE
 
 > [!IMPORTANT]
-> `h5p` commands run relative to the current working directory.
-> You can create multiple work directories each with different library setups.
+> H5P commands run relative to the current working directory.  
+> You can create multiple work directories each with different library setups.  
 
-0. Create a new folder for your first H5P development environment and change your current work dir to it.
+0. Create a new folder for your first H5P development environment and change your current work dir to it.  
 ```
 mkdir my_first_h5p_environment
 cd my_first_h5p_environment
@@ -43,9 +43,9 @@ h5p core
 ```
 h5p setup h5p-course-presentation
 ```
-This is required for running and editing content types in the "h5p-course-presentation" library.
-You can install other libraries listed by `h5p list` in the same way.
-For example, `h5p setup h5p-accordion` installs the "h5p-accordion" library and its dependencies.
+This is required for running and editing content types in the "h5p-course-presentation" library.  
+You can install other libraries listed by `h5p list` in the same way.  
+For example, `h5p setup h5p-accordion` installs the "h5p-accordion" library and its dependencies.  
 > [!NOTE]
 > You can [read more on setting up libraries here](assets/docs/setup.md).
 
@@ -53,10 +53,10 @@ For example, `h5p setup h5p-accordion` installs the "h5p-accordion" library and 
 ```
 h5p server
 ```
-You can now use your browser to view, edit, delete, import, export and create new content types.
+You can now use your browser to view, edit, delete, import, export and create new content types.  
 > [!IMPORTANT]
-> Remember that the folder where you run the H5P server is where the server will look for the libraries. If you run the setup commands in another folder then the server will not find those libraries.
+> Remember that the folder where you run the H5P server is where the server will look for the libraries. If you run the setup commands in another folder then the server will not find those libraries.  
 
 <video src="https://github.com/h5p/h5p-cli/assets/5208532/b33a12e6-3200-488c-81c6-eae41b13f512"></video>
 
-You can [find more commands in an overview](assets/docs/commands.md) or by running `h5p help`.
+You can [find more commands in an overview](assets/docs/commands.md) or by running `h5p help`.  

--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,16 @@
-An h5p toolkit for running, editing and developing h5p content types.  
+An H5P toolkit for running, editing and developing H5P content types.
 
-Make sure you have [git](https://git-scm.com/downloads), [NodeJS](https://nodejs.org/en/download/current) and [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) (usually included in NodeJS) installed.  
-Some of the commands listed here are Linux & MacOS specific. On Windows it’s recommended that you run them inside [git bash](https://git-scm.com/download/win).  
+Make sure you have [git](https://git-scm.com/downloads), [NodeJS](https://nodejs.org/en/download/current) and [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) (usually included in NodeJS) installed.
+Some of the commands listed here are Linux & MacOS specific. On Windows it’s recommended that you run them inside [git bash](https://git-scm.com/download/win).
 
 # INSTALLATION
 
-Uninstall any previous h5p-cli toolkit instance
+Uninstall any previous h5p-cli toolkit instance.
 ```
 npm uninstall -g h5p-cli
 npm uninstall -g h5p
 ```
-then install it from this repository.
+Then install it from this repository.
 ```
 git clone https://github.com/h5p/h5p-cli.git
 cd h5p-cli
@@ -18,45 +18,45 @@ npm install
 cd ..
 npm install -g ./h5p-cli
 ```
-You can now use `h5p` as a global command.  
+You can now use `h5p` as a global command.
 
 ![installation gif](assets/docs/install.gif)
 
 # QUICK START GUIDE
 
 > [!IMPORTANT]
-> h5p commands run relative to the current working directory.  
-> You can create multiple work directories each with different library setups.  
+> `h5p` commands run relative to the current working directory.
+> You can create multiple work directories each with different library setups.
 
-0. Create a new folder for your first h5p development environment and change your current work dir to it.  
+0. Create a new folder for your first H5P development environment and change your current work dir to it.
 ```
 mkdir my_first_h5p_environment
 cd my_first_h5p_environment
 ```
 
-1. Install the core h5p libraries.
+1. Install the core H5P libraries.
 ```
 h5p core
 ```
 
-2. Setup an h5p library such as h5p-course-presentation.
+2. Setup an H5P library such as h5p-course-presentation.
 ```
 h5p setup h5p-course-presentation
 ```
-This is required for running and editing content types in the h5p-course-presentation library.  
-You can install other libraries listed by `h5p list` in the same way.  
-For example, `h5p setup h5p-accordion` installs the "h5p-accordion" library and its dependencies.  
+This is required for running and editing content types in the "h5p-course-presentation" library.
+You can install other libraries listed by `h5p list` in the same way.
+For example, `h5p setup h5p-accordion` installs the "h5p-accordion" library and its dependencies.
 > [!NOTE]
-> You can read more on setting up libraries [here](assets/docs/setup.md).
+> You can [read more on setting up libraries here](assets/docs/setup.md).
 
 3. Start the development server.
 ```
 h5p server
 ```
-You can now use your browser to view, edit, delete, import, export and create new content types.  
+You can now use your browser to view, edit, delete, import, export and create new content types.
 > [!IMPORTANT]
-> Remember that the folder where you run the h5p server is where the server will look for the libraries. If you run the setup commands in another folder then the server will not find those libraries.  
+> Remember that the folder where you run the H5P server is where the server will look for the libraries. If you run the setup commands in another folder then the server will not find those libraries.
 
 <video src="https://github.com/h5p/h5p-cli/assets/5208532/b33a12e6-3200-488c-81c6-eae41b13f512"></video>
 
-Other h5p commands can be found [here](assets/docs/commands.md) or by running `h5p help`.  
+You can [find more commands in an overview](assets/docs/commands.md) or by running `h5p help`.


### PR DESCRIPTION
When merged in, will e.g.
- use H5P in capital spelling where the software name is used
- do not use "here" as link text - an a11y no-no
- fix typos