### PR TITLE
Exclude node_modules from livereload

### DIFF
--- a/config.js
+++ b/config.js
@@ -9,6 +9,7 @@ module.exports = {
   },
   files: {
     watch: true,
+    watchExclusions: [/node_modules\//],
     patterns: {
       allowed: /\.(json|png|jpg|jpeg|gif|bmp|tif|tiff|svg|eot|ttf|woff|woff2|otf|webm|mp4|ogg|mp3|txt|pdf|rtf|doc|docx|xls|xlsx|ppt|pptx|odt|ods|odp|xml|csv|diff|patch|swf|md|textile|js|css)$/,
       ignored: /^\.|~$/gi

--- a/server.js
+++ b/server.js
@@ -33,7 +33,10 @@ let port = config.port;
 app.listen(port, () => {
   console.log(`h5p content type development server running on http://localhost:${port}`);
 });
+
 if (config.files.watch) {
-  const eye = require('livereload').createServer();
+  const eye = require('livereload').createServer({
+    exclusions: config?.files?.watchExclusions ?? []
+  });
   eye.watch(config.folders.libraries);
 }


### PR DESCRIPTION
When merged in, will not watch `node_modules` folders for live reload (in a configurable fashion).

Just encountered:
```
node:internal/fs/watchers:247
    const error = new UVException({
                  ^

Error: ENOSPC: System limit for number of file watchers reached, watch [...]
```
when running `h5p server` - if you have many dependencies in a package, the number of files to watch can explode (in `node_modules`). Same if you just work on multiple libraries at the same time each contributing a `node_modules` folder.

Solved by adding a configuration item (just in case someone wants `node_modules` to be watched) and passing that as the `exclusion` property to livereload's `createServer` function. `.git` would also be a candidate, but that's covered by default already.