### PR TITLE
HFP-4040 Fix file extension detection

### DIFF
--- a/api.js
+++ b/api.js
@@ -310,7 +310,7 @@ module.exports = {
       if (!fs.existsSync(targetFolder)) {
         fs.mkdirSync(targetFolder);
       }
-      const ext = request.file.originalname.split('.')?.[1] || '';
+      const ext = request.file.originalname.split('.')?.pop() || '';
       const path = `${form.type}s/${request.file.filename}.${ext}`;
       const targetFile = `${targetFolder}/${request.file.filename}.${ext}`;
       fs.renameSync(`${request.file.path}`, targetFile);


### PR DESCRIPTION
When merged in, will use the last dot-separated segment from a file name instead of using the 2nd one.