### PR TITLE
HFP-4060 Fix resetting state after content changed

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 const he = require('he');
 const imageSize = require('image-size');
 const logic = require('./logic.js');
@@ -314,7 +315,11 @@ module.exports = {
   saveContent: (request, response, next) => {
     try {
       const input = JSON.parse(request.body.parameters);
-      fs.writeFileSync(`content/${request.params.folder}/content.json`, JSON.stringify(input.params));
+
+      const currentParams = fs.readFileSync(`content/${request.params.folder}/content.json`, 'utf-8');
+      const newParams = JSON.stringify(input.params);
+
+      fs.writeFileSync(`content/${request.params.folder}/content.json`, newParams);
       const infoFile = `content/${request.params.folder}/h5p.json`;
       let info = JSON.parse(fs.readFileSync(infoFile, 'utf-8'));
       info = {...info, ...input.metadata};
@@ -344,6 +349,12 @@ module.exports = {
         }
       }
       const simple = request.query.simple;
+
+      if (currentParams !== '{}' && currentParams !== newParams) {
+        // Content has been changed, resetting user data to prevent invalid state
+        resetContentUserData(request.params.folder);
+      }
+
       response.redirect(`/${simple ? 'edit' : 'view'}/${request.params.library}/${request.params.folder}${simple ? '?simple=1' : ''}`);
     }
     catch (error) {
@@ -785,3 +796,26 @@ const getLangLabels = async () => {
   }
   return await logic.getFile(langFile, true);
 }
+
+/**
+ * Reset content user data.
+ * @param {string} folder Folder name (contentId) if content to reset user data for.
+ */
+const resetContentUserData = (folder) => {
+  const sessionsDir = `content/${folder}/sessions`;
+
+  fs.readdirSync(sessionsDir).forEach((file) => {
+    if (path.extname(file) !== '.json') {
+      return;
+    }
+
+    const dataFile = path.join(sessionsDir, file);
+
+    const data = JSON.parse(fs.readFileSync(dataFile, 'utf8'));
+    data.resume.forEach(entry => {
+      entry.state = null; // Means to reset state for H5P core
+    });
+
+    fs.writeFileSync(dataFile, JSON.stringify(data, null, 2));
+  });
+};


### PR DESCRIPTION
When merged in, will reset the previous content state of all sessions after content was edited in order to prevent sending states to content types that do not match changed parameters - same behavior as other H5P integrations.