### PR TITLE
HFP-4061 Add reset button for sessions

### DIFF
--- a/assets/languages/ar.json
+++ b/assets/languages/ar.json
@@ -15,6 +15,7 @@
    "lang_contentCreatedFor": "تم إنشاء المحتوى لـ",
    "lang_userStateSession": "جلسة حالة المستخدم",
    "lang_newSession": "جلسة جديدة",
+   "lang_resetSession": "reset session",
    "lang_sessionName": "اسم الجلسة",
    "lang_createSession": "إنشاء جلسة",
    "lang_saveAllChanges": "احفظ كل التغييرات"

--- a/assets/languages/de.json
+++ b/assets/languages/de.json
@@ -15,6 +15,7 @@
   "lang_contentCreatedFor": "Inhalt erstellt für",
   "lang_userStateSession": "Benutzerstatussitzung",
   "lang_newSession": "neue Sitzung",
+  "lang_resetSession": "Sitzung zurücksetzen",
   "lang_sessionName": "Sitzungsname",
   "lang_createSession": "Sitzung erstellen",
   "lang_saveAllChanges": "Alle Änderungen speichern"

--- a/assets/languages/en.json
+++ b/assets/languages/en.json
@@ -15,6 +15,7 @@
   "lang_contentCreatedFor": "content created for",
   "lang_userStateSession": "user state session",
   "lang_newSession": "new session",
+  "lang_resetSession": "reset session",
   "lang_sessionName": "session name",
   "lang_createSession": "create session",
   "lang_saveAllChanges": "save all changes"

--- a/assets/languages/es.json
+++ b/assets/languages/es.json
@@ -15,6 +15,7 @@
   "lang_contentCreatedFor": "contenido creado para",
   "lang_userStateSession": "sesión de estado del usuario",
   "lang_newSession": "nueva sesión",
+  "lang_resetSession": "restablecer sesión",
   "lang_sessionName": "nombre de la sesión",
   "lang_createSession": "crear sesión",
   "lang_saveAllChanges": "guardar todos los cambios"

--- a/assets/languages/fr.json
+++ b/assets/languages/fr.json
@@ -16,6 +16,7 @@
   "lang_userStateSession": "session d'état de l'utilisateur",
   "lang_newSession": "nouvelle session",
   "lang_sessionName": "nom de la session",
+  "lang_resetSession": "réinitialiser session",
   "lang_createSession": "créer une session",
   "lang_saveAllChanges": "enregistrer toutes les modifications"
 }

--- a/assets/languages/it.json
+++ b/assets/languages/it.json
@@ -16,6 +16,7 @@
   "lang_userStateSession": "sessione stato utente",
   "lang_newSession": "nuova sessione",
   "lang_sessionName": "nome sessione",
+  "lang_resetSession": "reset session",
   "lang_createSession": "crea sessione",
   "lang_saveAllChanges": "salva tutte le modifiche"
 }

--- a/assets/languages/nl.json
+++ b/assets/languages/nl.json
@@ -16,6 +16,7 @@
   "lang_userStateSession": "gebruikersstatussessie",
   "lang_newSession": "nieuwe sessie",
   "lang_sessionName": "sessienaam",
+  "lang_resetSession": "reset session",
   "lang_createSession": "sessie aanmaken",
   "lang_saveAllChanges": "alle wijzigingen opslaan"
 }

--- a/assets/languages/nn.json
+++ b/assets/languages/nn.json
@@ -16,6 +16,7 @@
   "lang_userStateSession": "brukerstatusøkt",
   "lang_newSession": "ny økt",
   "lang_sessionName": "sesjonsnavn",
+  "lang_resetSession": "tilbakestill økt",
   "lang_createSession": "opprett økt",
   "lang_saveAllChanges": "lagre alle endringer"
 }

--- a/assets/languages/pl.json
+++ b/assets/languages/pl.json
@@ -16,6 +16,7 @@
   "lang_userStateSession": "sesja stanu użytkownika",
   "lang_newSession": "nowa sesja",
   "lang_sessionName": "nazwa sesji",
+  "lang_resetSession": "reset session",
   "lang_createSession": "utwórz sesję",
   "lang_saveAllChanges": "zapisz wszystkie zmiany"
 }

--- a/assets/languages/sv.json
+++ b/assets/languages/sv.json
@@ -16,6 +16,7 @@
   "lang_userStateSession": "användartillståndssession",
   "lang_newSession": "ny session",
   "lang_sessionName": "sessionens namn",
+  "lang_resetSession": "reset session",
   "lang_createSession": "skapa session",
   "lang_saveAllChanges": "spara alla ändringar"
 }

--- a/assets/templates/view.html
+++ b/assets/templates/view.html
@@ -71,6 +71,7 @@
     const sessionName = document.getElementById('sessionName');
     const sessionSelect = document.getElementById('sessions');
     const newSessionButton = document.getElementById('newSessionButton');
+    const resetSessionButton = document.getElementById('resetSessionButton');
     const saveSessionButton = document.getElementById('saveSessionButton');
     const session = '{session}';
     const sessions = {sessions};
@@ -82,6 +83,29 @@
     const newSessionEvent = () => {
       newSession.classList.toggle('hidden');
     }
+
+    /*
+     * Reset session/task
+     */
+    const resetSessionEvent = () => {
+      try {
+        const iframeH5PObject =
+          document.querySelector('iframe.h5p-iframe').contentWindow.H5P;
+
+        const instance = iframeH5PObject.instances[0];
+
+        if (typeof instance?.resetTask !== 'function') {
+          return; // Library does not implement resetTask()
+        }
+
+        instance.resetTask();
+        iframeH5PObject.deleteUserData(instance.contentId, 'state', 0);
+      }
+      catch(error) {
+        // Intentionally left blank
+      }
+    }
+
     const saveSessionEvent = () => {
       params.set('session', sessionName.value);
       window.location.href = `/view/{library}/{folder}?${params.toString()}`;
@@ -94,6 +118,7 @@
     sessionSelect.innerHTML = options;
     sessionSelect.addEventListener('change', sessionChanged);
     newSessionButton.addEventListener('click', newSessionEvent);
+    resetSessionButton.addEventListener('click', resetSessionEvent);
     saveSessionButton.addEventListener('click', saveSessionEvent);
   });
 </script>
@@ -142,6 +167,7 @@
         <input type="text" class="input" id="sessionName" placeholder="{lang_sessionName}">
         <div class="button" id="saveSessionButton">{lang_createSession}</div>
       </div>
+      <button class="button" id="resetSessionButton">{lang_resetSession}</div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
When merged in, will add a "Reset session" button that allows the developer to do exactly that:
Reset a session while also trying to call "resetTask" on the instance. Thus, it essentially does the same as the "Start Over" button on H5P.com (minus hiding the attempts bar that is not available in the regular H5P core).