### PR TITLE
HFP-4151 Fix allowed type detection for files

### DIFF
--- a/api.js
+++ b/api.js
@@ -667,7 +667,7 @@ const validateFileForUpload = (uploadFieldType, mimeType, extension) => {
         .split('|');
 
       mimeType = '*'; // Allow allowedExtensions for all mime types
-      allowed = { mimeType : allowedExtensions };
+      allowed = { [mimeType]: allowedExtensions };
       break;
 
     default:


### PR DESCRIPTION
When merged in, will fix the detection of allowed file types.

Currently, `mimeType` is set as an object key, not the value of the variable named `mimeType`.