### PR TITLE
HFP-4240 Remove patch version from H5PIntegration.libraryDirectories

### DIFF
--- a/api.js
+++ b/api.js
@@ -746,7 +746,7 @@ const computePreloaded = async (library, baseUrl) => {
     if (!folder) {
       continue;
     }
-    const label = `${entry.id}-${entry.version.major}.${entry.version.minor}.${entry.version.patch}`;
+    const label = `${entry.id}-${entry.version.major}.${entry.version.minor}`;
     const languageFolder = `${config.folders.libraries}/${folder}/language`;
     const langFile = `${languageFolder}/${session.language}.json`;
     if (fs.existsSync(langFile)) {


### PR DESCRIPTION
When merged in, will remove the patch version from entries in `H5PIntegration.libraryDirectories`.