### PR TITLE
HFP-4286 Fix missing h5p-fonts

### DIFF
--- a/assets/templates/edit.html
+++ b/assets/templates/edit.html
@@ -57,6 +57,7 @@
           "/{libraries}/h5p-php-library/styles/h5p.css",
           "/{libraries}/h5p-php-library/styles/h5p-confirmation-dialog.css",
           "/{libraries}/h5p-php-library/styles/h5p-core-button.css",
+          "/{libraries}/h5p-php-library/styles/h5p-fonts.css",
           "/{libraries}/h5p-php-library/styles/h5p-theme.css",
           "/{libraries}/h5p-php-library/styles/h5p-theme-variables.css",
           "/{libraries}/h5p-php-library/styles/h5p-tooltip.css",


### PR DESCRIPTION
When merged in, will add the new h5p-fonts styles that are currently missing (should probably be loaded via H5P core anyway like other files).