### PR TITLE
Refactor server and api to enable adding new endpoints

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -298,7 +298,7 @@ const cli = {
   },
   // run the dev server
   server: () => {
-    require('./server.js');
+    require('./src/server/server.js');
   },
   // help section
   help: (command) => {

--- a/src/server/api.js
+++ b/src/server/api.js
@@ -2,11 +2,11 @@ const fs = require('fs');
 const path = require('path');
 const he = require('he');
 const imageSize = require('image-size');
-const logic = require('./logic.js');
-const config = require('./configLoader.js');
-const l10n = require('./assets/l10n.json');
+const logic = require('../../logic.js');
+const config = require('../../configLoader.js');
+const l10n = require('../../assets/l10n.json');
 const supportedLanguages = require(`${require.main.path}/${config.folders.assets}/languageCatcher.js`);
-const userSession = require('./src/server/user_session.js');
+const userSession = require('./user_session.js');
 let contentSession = {
   name: 'main-session',
   language: 'en',

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const config = require('./configLoader.js');
+const config = require('../../configLoader.js');
 const multer = require('multer')({ dest: `./${config.folders.temp}` });
 const api = require('./api.js');
 let app = express();

--- a/src/server/user_session.js
+++ b/src/server/user_session.js
@@ -1,0 +1,25 @@
+const config = require("../../configLoader.js");
+const fs = require("fs");
+const logic = require("../../logic.js");
+
+let userSession = {
+    language: 'en'
+};
+
+module.exports = {
+    session: userSession,
+
+    updateFromQuery: (request) => {
+        if(request.query?.language){
+            userSession['language'] = request.query?.language;
+        }
+    },
+
+    getLangLabels: async () => {
+        let langFile = `${require.main.path}/${config.folders.assets}/languages/${userSession.language}.json`;
+        if (!fs.existsSync(langFile)) {
+            langFile = `${config.folders.assets}/languages/en.json`;
+        }
+        return await logic.getFile(langFile, true);
+    }
+}


### PR DESCRIPTION
This refactor changes no behavior and is meant to make it easier to add the [Content Type Browser](https://github.com/h5p/h5p-cli/pull/166).
This is separated into its own PR to keep both PRs simpler to understand.

This PR creates a `src/server/` directory and moves the existing files there:
- `api.js` -> `src/server/api.js`
- `server.js` -> `src/server/server.js`

This also creates the file `src/server/user_session.js` and separates the session's language filter away from the session for the content. This is to enable the Type Browser to easily use the translation helper.