### PR TITLE
Adds a "Content Type Browser" to the server

### DIFF
--- a/assets/languages/de.json
+++ b/assets/languages/de.json
@@ -18,5 +18,6 @@
   "lang_resetSession": "Sitzung zurücksetzen",
   "lang_sessionName": "Sitzungsname",
   "lang_createSession": "Sitzung erstellen",
-  "lang_saveAllChanges": "Alle Änderungen speichern"
+  "lang_saveAllChanges": "Alle Änderungen speichern",
+  "lang_installed_libraries": "Inhaltstypen"
 }

--- a/assets/languages/en.json
+++ b/assets/languages/en.json
@@ -18,5 +18,6 @@
   "lang_resetSession": "reset session",
   "lang_sessionName": "session name",
   "lang_createSession": "create session",
-  "lang_saveAllChanges": "save all changes"
+  "lang_saveAllChanges": "save all changes",
+  "lang_installed_libraries": "Content Types"
 }

--- a/assets/languages/es.json
+++ b/assets/languages/es.json
@@ -18,5 +18,6 @@
   "lang_resetSession": "restablecer sesión",
   "lang_sessionName": "nombre de la sesión",
   "lang_createSession": "crear sesión",
-  "lang_saveAllChanges": "guardar todos los cambios"
+  "lang_saveAllChanges": "guardar todos los cambios",
+  "lang_installed_libraries": "Tipo de contenido"
 }

--- a/assets/languages/fr.json
+++ b/assets/languages/fr.json
@@ -18,5 +18,6 @@
   "lang_sessionName": "nom de la session",
   "lang_resetSession": "réinitialiser session",
   "lang_createSession": "créer une session",
-  "lang_saveAllChanges": "enregistrer toutes les modifications"
+  "lang_saveAllChanges": "enregistrer toutes les modifications",
+  "lang_installed_libraries": "Type de contenu"
 }

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -110,6 +110,9 @@ body {
 .dashboard:before {
   content: "\e903";
 }
+.type-browser:before {
+  content: "\1F3EA";
+}
 .save-button {
   background-color: #388E3C;
   border-color: #388E3C;

--- a/assets/templates/dashboard.html
+++ b/assets/templates/dashboard.html
@@ -44,6 +44,9 @@
         <div class="button import" id="importContentButton" onclick="runner.toggleImportContent()">
           <span class="button-label">{lang_import}</span>
         </div>
+        <a href="/type_browser/" class="button type-browser" id="typeBrowserButton">
+          <span class="button-label">{lang_installed_libraries}</span>
+        </a>
         <div class="languages">
           {lang_language}
           <select id="languages" class="selector" onchange="runner.changeLanguage()">

--- a/assets/type_browser/components/h5pcli-content-type.js
+++ b/assets/type_browser/components/h5pcli-content-type.js
@@ -1,0 +1,281 @@
+/**
+ * Display an H5P Content Type's Library, Semantics, and xAPI examples
+ * Can be displayed collapsed for an index page, or expanded
+ *
+ * Expects an "augmented library" JSON block like this:
+ * {
+ * "links_data": {
+ *      "library": "/libraries/H5P.TrueFalse-1.8/library.json",
+ *      "xapi_examples": "/type_browser/H5P.TrueFalse-1.8/xapi_examples",
+ *      "semantics": "/libraries/H5P.TrueFalse-1.8/semantics.json"
+ *  },
+ * "links_web": {
+ *      "docPage": "/type_browser/H5P.TrueFalse-1.8/",
+ *      "fixtures": "/libraries/H5P.TrueFalse-1.8/tests/fixtures"
+ *  },
+ * "icon_url": "/libraries/H5P.TrueFalse-1.8/icon.svg",
+ * "library": { ... Typical H5P Library ... }
+ * }
+ *
+ * @attribute {string} src - Optional path to the augmented library json definition for the type
+ * @attribute {string} collapsed - Optional Displays just the title and links with the Library, Semantics, and xAPI sections hidden within details tabs.
+ *
+ * @slot title - Title slot, filled with the type title and version number by default
+ * @slot details - Slots for the content tabs for Library, Semantics, and xAPI. Light-dom enables js-highlight script to see it
+ *
+ * @tagname h5pcli-content-type
+ *
+ * @example HTML Usage
+ * <h5pcli-content-type class="item" src="./library.json"></h5pcli-content-type>
+ *
+ * @example Javascript Instantiation
+ * let type = document.createElement('h5pcli-content-type');
+ * type.setAttribute("collapsed", "");
+ * type.renderFromAugmentedLibrary(lib);
+ * this.append(type);
+ *
+ */
+export default class H5pcliContentType extends HTMLElement {
+    static observedAttributes = ['src'];
+
+    constructor() {
+        super();
+
+        let shadowRoot = this.attachShadow({ mode: 'open' });
+        shadowRoot.appendChild(H5pcliContentType.template.content.cloneNode(true));
+
+        this.contentType = null;
+
+        this._slot_links = this.shadowRoot.querySelector('ul[name="links"]');
+        this._tabs = this.shadowRoot.querySelector('.tabs-container');
+        this._icon = this.shadowRoot.querySelector('.itemIcon img');
+        this._docLink = this.shadowRoot.querySelector('.doc-link');
+        this._memoizedSearch = {
+            title: null,
+            dependencies: null
+        };
+    }
+
+    static get template() {
+        let tmpl = document.createElement('template');
+        tmpl.innerHTML = `
+			<style>
+                li {
+                    display: inline;
+                    padding: 1rem;
+                }
+                .itemIcon {
+                    display: inline-block;
+                    flex-basis: 5%;
+                    pointer-events: auto;
+                    padding: 0 0.5em 0 1.5em;
+                }
+                .item {
+                    pointer-events: auto;
+                    flex-basis: 65%;
+                    padding-left: 1em;
+                }
+                .item slot[name=title]{
+                    font-size: 1.25em;
+                    font-weight: 600;
+                    display: inline;
+                }
+                .doc-link {
+                    text-decoration: unset;
+                    padding-left: 1rem;
+                }
+                :host(:not([collapsed])) .doc-link {
+                    display: none;
+                }
+                :host([collapsed]) .tabs-container {
+                  position: relative;
+                  display: grid;
+                  grid-template-rows: auto 1fr;
+                  grid-template-columns: repeat(3, auto);
+                  width: 90%;
+                  margin-top: 10px;
+                }
+			</style>
+			    <div class="itemIcon"><img src="/assets/icon.svg"></div>
+			    <div class="item">
+		            <slot name="title"></slot>
+		            <span class="doc-link"></span>
+		            <ul name="links"></ul>
+                    <div class="tabs-container">
+                        <slot name="details"></slot>
+                    </div>
+                </div>
+		`;
+        return tmpl;
+    }
+
+    /*
+    The proper layout of tabs depends on the correct count, call this to change from the default 3 tabs
+     */
+    setTabColumns(count=3){
+        this._tabs.style.gridTemplateColumns = `repeat(${count}, auto)`
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if(name === 'src'){
+            this.fetchSrcUpdate(newValue);
+        }
+    }
+
+    async fetchSrcUpdate(src) {
+        try {
+            const response = await fetch(src);
+            if (!response.ok) {
+                throw new Error(`Response status: ${response.status}`);
+            }
+
+            const json = await response.json();
+            this.renderFromAugmentedLibrary(json);
+        } catch (error) {
+            console.error(error.message);
+        }
+    }
+
+    isRunnable(){
+        return this.contentType.library.runnable === 1;
+    }
+
+    matchesSearch(searchString, includeDependencies = false) {
+        if (this._memoizedSearch.title === null) {
+            this._memoizedSearch.title = this.contentType.library.title.toLowerCase();
+        }
+        let searchLowered = searchString.toLowerCase();
+
+        const titleMatch = this._memoizedSearch.title.includes(searchLowered);
+
+        if (includeDependencies) {
+            return titleMatch || this.matchesDependencies(searchLowered);
+        }
+
+        return titleMatch;
+    }
+
+    matchesDependencies(searchLowered){
+        if (this._memoizedSearch.dependencies === null) {
+            this._memoizedSearch.dependencies = [
+                ...(this.contentType.library.preloadedDependencies || []).map(dep => dep.machineName.toLowerCase()),
+                ...(this.contentType.library.editorDependencies || []).map(dep => dep.machineName.toLowerCase())
+            ];
+        }
+
+        return this._memoizedSearch.dependencies.some(dep => dep.includes(searchLowered));
+    }
+
+    /*
+    Takes an Augmented Library object (from src attribute or directly)
+    Parses Title and version number, adds classes for runnable and notrunnable, sets the icon,
+    adds tabs for h5pcli-library-overview, h5pcli-semantics, and h5pcli-xapi-examples
+    and adds links for any values in the `links_web` property
+     */
+    renderFromAugmentedLibrary(jsonStringOrObj){
+        if(!jsonStringOrObj){return;}
+        let json_parsed;
+
+        try{
+            json_parsed = (typeof jsonStringOrObj === 'string') ? JSON.parse(jsonStringOrObj) : jsonStringOrObj;
+        } catch(err) {
+            console.log("Error parsing H5P Library json", err, json_parsed)
+            return;
+        }
+
+        this.contentType = json_parsed;
+        let library = this.contentType.library
+        if(library.title){
+            let title = document.createElement('span');
+            let version = `v${library.majorVersion}.${library.minorVersion}.${library.patchVersion}`
+            title.textContent = `${library.title} - ${version}`;
+            title.slot = "title";
+            this.append(title);
+        }
+
+        if(this.isRunnable()){
+            this.classList.add('runnable');
+        } else {
+            this.classList.add('notrunnable');
+        }
+
+        if(this.contentType.icon_url){
+            this._icon.src = this.contentType.icon_url;
+        }
+
+        let libraryOverview = document.createElement('h5pcli-library-overview');
+        libraryOverview.parseLibrary(library);
+        this.addContentTab( "Library Information", libraryOverview);
+
+        if(this.contentType.links_data){
+            if(this.contentType.links_data['semantics']){
+                let semantics = document.createElement('h5pcli-semantics');
+                semantics.src = this.contentType.links_data['semantics'];
+                this.addContentTab( "Semantics", semantics);
+            } else if (this.isRunnable()) {
+                let message = document.createElement('p');
+                message.textContent = `No semantics.`;
+                this.addContentTab("(No Semantics)", message);
+            }
+
+            if(this.contentType.links_data['xapi_examples']){
+                let examples = document.createElement('h5pcli-xapi-examples');
+                examples.src = this.contentType.links_data['xapi_examples'];
+                this.addContentTab( "xAPI Events", examples);
+            } else if (this.isRunnable()){
+                let message = document.createElement('p');
+                message.innerHTML = `No examples for this type. Add them to <code>/${library.machineName}/events/xapi/examples/</code> to view here.`;
+                this.addContentTab("xAPI Events", message);
+            }
+        }
+
+        // links to new pages
+        if(this.contentType.links_web){
+            for (const [link, path] of Object.entries(this.contentType.links_web)) {
+                if(link === 'docPage'){
+                    let link = document.createElement('a');
+                    link.href = this.contentType.links_web.docPage;
+                    link.textContent = 'Full Docs';
+                    this._docLink.append(link);
+                } else {
+                    let li = document.createElement('li')
+                    let aref = document.createElement('a')
+                    aref.href = path;
+                    aref.textContent = link;
+                    // aref.target = "_blank";
+                    li.append(aref);
+                    this._slot_links.append(li);
+                }
+            }
+        }
+    }
+
+
+    addContentTab(title, node){
+        let div = document.createElement('div');
+        div.append(node);
+
+        this.addDetails(title, div);
+    }
+
+    addDetails(title, content){
+        let details = document.createElement('details')
+        if(this.hasAttribute('collapsed')){
+            details.name = "details";
+        } else {
+            details.setAttribute("open", "");
+        }
+        details.slot = "details";
+        let summary = document.createElement('summary');
+        summary.textContent = title;
+        details.append(summary);
+        content.setAttribute("class", "tab-content")
+        details.append(content);
+        this.append(details);
+    }
+
+}
+
+if( !customElements.get('h5pcli-content-type')){
+    customElements.define('h5pcli-content-type', H5pcliContentType);
+}

--- a/assets/type_browser/components/h5pcli-library-overview.js
+++ b/assets/type_browser/components/h5pcli-library-overview.js
@@ -1,0 +1,176 @@
+/**
+ * Display a parsed overview of an H5P Library and embed the JSON for display
+ * Can not be used as just HTML, must be instantiated in JS.
+ *
+ * The attributes are parsed into a shadow-dom table for display
+ *
+ * @slot json - You can put some elements here
+ *
+ * @tagname h5pcli-library-overview
+ *
+ * @example Javascript Instantiation
+ * let libraryOverview = document.createElement('h5pcli-library-overview');
+ * libraryOverview.parseLibrary(libraryJson);
+ * this.append(libraryOverview);
+ *
+ */
+export default class H5pcliLibraryOverview extends HTMLElement {
+
+    constructor() {
+        super();
+
+        let shadowRoot = this.attachShadow({mode: 'open'});
+        shadowRoot.appendChild(H5pcliLibraryOverview.template.content.cloneNode(true));
+
+        this.description = this.shadowRoot.querySelector('.description');
+    }
+
+    static get template() {
+        let t = document.createElement('template')
+        t.innerHTML = `
+        <style>
+        .overview{
+            display: flex;
+            gap: 20px;
+            margin-bottom: 10px;
+            align-items: flex-start;
+        }
+        table {
+            border-collapse: collapse;
+            margin: 20px 0;
+            font-size: 18px;
+            max-width: 45%;
+            box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+        }
+        
+        table > caption {
+            margin: 10px;
+            /*font-size: 24px;*/
+            font-weight: bold;
+        }
+        
+        table th, table td {
+            padding: 12px 15px;
+            text-align: left;
+        }
+        
+        table > thead tr {
+            background-color: #4CAF50;
+            color: white;
+        }
+        
+        table > tbody tr:nth-child(even) {
+            background-color: #f2f2f2;
+        }
+        </style>
+        <p class="description"></p>
+        <div class="overview">
+            <table class="library">
+                <caption>Basics</caption>
+                <tbody>
+                </tbody>
+            </table>
+            <table class="dependencies">
+                <caption>Dependencies</caption>
+                <tbody>
+                </tbody>
+            </table>
+        </div>
+        <slot name="json"></slot>
+        `;
+
+        return t;
+    }
+
+    /*
+    Display an H5P Library JSON block in a table and embedded JSON viewer
+     */
+    async parseLibrary(library){
+        this.addJson(library);
+        if(library.description){
+            this.description.textContent = library.description;
+        }
+        let basics = this.shadowRoot.querySelector('.library tbody');
+        basics.append(this.newRow('Title', library.title));
+        basics.append(this.newRow('Machine Name', library.machineName));
+        basics.append(this.newRow('Version', this.getVersionString(library)));
+        basics.append(this.newRow('Runnable', library.runnable === 1));
+        if(library.author){
+            basics.append(this.newRow('Author', library.author));
+        }
+        if(library.license){
+            basics.append(this.newRow('License', library.license));
+        }
+        if(library.embedTypes){
+            basics.append(this.newRow("Embed Types", library.embedTypes.join()));
+        }
+
+        let deps = this.shadowRoot.querySelector('.dependencies tbody');
+        deps.append(this.newRow("Core API", this.getVersionString(library.coreApi || {})));
+        deps.append(this.newRow("Libraries", this.dependencies(library.preloadedDependencies || [])));
+        deps.append(this.newRow("Editors", this.dependencies(library.editorDependencies || [])));
+    }
+
+    newRow(fieldName, value){
+        let tr = document.createElement('tr');
+        let tdName = document.createElement('td');
+        tdName.textContent = fieldName;
+        let tdValue = document.createElement('td');
+        if(typeof value === 'object'){
+            tdValue.append(value);
+        } else {
+            tdValue.textContent = value
+        }
+        tr.append(tdName);
+        tr.append(tdValue);
+        return tr;
+    }
+
+    getVersionString(library){
+        if(library.majorVersion){
+            return `v${library.majorVersion}.${library.minorVersion}${library.patchVersion ? "." + library.patchVersion : ''}`;
+        } else {
+            return "None"
+        }
+    }
+
+    dependencies(deps){
+        if(deps.length === 0){
+            return "None";
+        } else{
+            let ul = document.createElement('ul');
+            deps.forEach((dep) =>{
+                let li = document.createElement('li');
+                li.textContent = `${dep.machineName} - ${this.getVersionString(dep)}`;
+                ul.append(li);
+            })
+            return ul
+        }
+    }
+
+    addJson(library){
+        let details = document.createElement('details');
+        details.slot = "json";
+        let summary = document.createElement('summary');
+        summary.textContent = "Library JSON";
+        details.append(summary);
+        let div = document.createElement('div');
+        let pre = document.createElement('pre');
+        let code = document.createElement('code')
+        code.setAttribute("class", "language-json")
+        code.textContent = JSON.stringify(library, undefined, 2)
+        pre.append(code);
+        div.append(pre);
+        details.append(div);
+
+        this.append(details);
+
+        if(typeof hljs !== "undefined"){
+            try{hljs.highlightElement(code);} catch {console.log("hljs loaded, but failed to highlight xapi event.")}
+        }
+    }
+}
+
+if( !customElements.get('h5pcli-library-overview')){
+    customElements.define('h5pcli-library-overview', H5pcliLibraryOverview);
+}

--- a/assets/type_browser/components/h5pcli-semantics-docs.js
+++ b/assets/type_browser/components/h5pcli-semantics-docs.js
@@ -1,0 +1,342 @@
+/**
+ * Display H5P Semantics JSON in a table sorted by priority
+ * Adds documentation links and easy access preview for semantics properties
+ *
+ * Can not be used as just HTML, must be instantiated in JS.
+ *
+ * @tagname h5pcli-semantics-docs
+ *
+ * @example Javascript Instantiation
+ * let docs = document.createElement('h5pcli-semantics-docs');
+ * await docs.parseSemantics(semanticsJson);
+ * this.append(docs);
+ */
+export default class H5pcliSemanticsDocs extends HTMLElement {
+
+    static semanticsDocUrl = 'https://h5p.org/semantics/'
+    // The formally documented types, URL anchors only exist for these
+    static semanticTypes = ['text', 'number', 'boolean', 'group', 'list', 'select', 'library', 'image', 'video', 'audio', 'file'];
+    // The formally documented attributes, URL anchors only exist for these
+    static semanticAttributes = ['name', 'type', 'importance', 'label', 'description', 'optional', 'default', 'common', 'widget', 'widgets', 'field', 'fields', 'max-length', 'regexp', 'enter-mode', 'tags', 'font', 'min', 'max', 'step', 'decimals', 'entity', 'is-sub-content', 'expanded', 'options', 'important'];
+    static semanticWidgets = ['textarea', 'html', 'color-selector', 'show-when'];
+    static semanticBasicAttributes = H5pcliSemanticsDocs.semanticAttributes.slice(0, 5);
+
+    constructor() {
+        super();
+
+        let shadowRoot = this.attachShadow({ mode: 'open' });
+        shadowRoot.appendChild(H5pcliSemanticsDocs.template.content.cloneNode(true));
+
+        this._table = this.shadowRoot.querySelector('table tbody');
+        this._previewcontainer = this.shadowRoot.querySelector('#previewcontainer');
+    }
+
+    static get template() {
+        let tmpl = document.createElement('template');
+        tmpl.innerHTML = `
+			<style>
+            .semantics {
+                border-collapse: collapse;
+                margin: 20px 0;
+                font-size: 18px;
+                min-width: 400px;
+                box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+            }
+            
+            .semantics > caption {
+                margin: 10px;
+                font-size: 24px;
+                font-weight: bold;
+            }
+            
+            .semantics th, .semantics td {
+                padding: 12px 15px;
+                text-align: left;
+            }
+            
+            .semantics > thead tr {
+                background-color: #4CAF50;
+                color: white;
+            }
+            
+            .semantics > tbody tr:nth-child(odd) {
+                background-color: #f2f2f2;
+            }
+            
+            .semantics > tbody tr:nth-child(even) {
+                background-color: white;
+            }
+            
+            .semantics > tbody tr:not(.attribute-list):hover {
+                background-color: #ddd;
+            }
+            
+            .attribute-list {
+                display: none; /* Hidden by default */
+                margin-top: 10px;
+                /*background-color: #f2f2f2;*/
+                padding: 10px;
+                border: 1px solid #ddd;
+            }
+            
+            .clickable {
+                cursor: pointer;
+                color: blue;
+                text-decoration: underline;
+            }
+            .preview {
+                cursor: pointer;
+                position: relative;
+                display: inline;
+                margin-left: 10px;
+            }
+            
+            .nested-attributes {
+                margin-left: 20px;
+            }
+            .nested-attributes table {
+                width: 100%;
+                border-collapse: collapse;
+                margin-top: 20px;
+            }
+    
+            .nested-attributes th, .nested-attributes td {
+                border: 1px solid #ccc;
+                padding: 8px;
+                text-align: left;
+            }
+            
+            a[target="_blank"]::after {
+                content: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAQElEQVR42qXKwQkAIAxDUUdxtO6/RBQkQZvSi8I/pL4BoGw/XPkh4XigPmsUgh0626AjRsgxHTkUThsG2T/sIlzdTsp52kSS1wAAAABJRU5ErkJggg==);
+                margin: 0 3px 0 5px;
+            }
+            
+            #docPreview {
+              position: fixed;
+              position-anchor: --doc-preview;
+              top: calc(anchor(bottom) + 5px);
+              justify-self: anchor-center;
+              width: 90vw; 
+              max-width: 600px;
+              height: 200px; /* Height of the iframe */
+              border: 5px dotted #1a73d9; /* Border for the iframe */
+            }
+
+            .anchor{
+                anchor-name: --doc-preview;
+            }
+
+			</style>
+			
+            <table class="semantics">
+                <caption>Content Type Semantics and their Attributes</caption>
+                <thead>
+                    <tr>
+                        <th>name</th>
+                        <th>type</th>
+                        <th>importance</th>
+                        <th>label</th>
+                        <th>description</th>
+                        <th>Other Attributes</th>
+                    </tr>
+                </thead>
+                <tbody>
+                </tbody>
+            </table>
+            <div id="previewcontainer"></div>
+			
+		`;
+        return tmpl;
+    }
+
+    connectedCallback() {
+    }
+
+    /*
+    This is the primary start-render function, must be called with semantics JSON
+    Sorts the semantics by the `importance` field then adds to table in alphabetical order
+     */
+    async parseSemantics(semanticsJson) {
+        let groupedMap = Map.groupBy(semanticsJson, ({importance}) => importance);
+
+        this.addRows(groupedMap.get('high') || []);
+        this.addRows(groupedMap.get('medium') || []);
+        this.addRows(groupedMap.get('low') || []);
+        this.addRows(groupedMap.get(undefined) || []);
+    }
+
+    /**
+     * Helper functions for generating HTML table rows/columns
+     */
+
+
+    addRows(semantics){
+        semantics = semantics.sort((a, b) => a.name.localeCompare(b.name));
+        for (const field of semantics) {
+            this.addRow(field);
+        }
+    }
+
+    addRow(semantic){
+        let row = document.createElement('tr');
+        row.innerHTML = `
+            <td>${semantic.name}</td>
+            <td>${semantic.type}</td>
+            <td>${semantic.importance}</td>
+            <td>${semantic.label}</td>
+            <td>${semantic.description || ''}</td>
+        `;
+        let col = document.createElement('td');
+        col.classList.add('clickable');
+        col.id = `${semantic.name}-toggle`;
+        col.onclick = ()=>{this.toggleAttributes(semantic.name, col.id)};
+        col.textContent = 'Show all';
+        row.append(col);
+
+        this._table.append(row);
+        this.addAllAttributesRow(semantic)
+    }
+
+    addAllAttributesRow(semantic){
+        let row = document.createElement('tr');
+        row.id = semantic.name;
+        row.classList = ['attribute-list'];
+        let col = document.createElement('td');
+        col.colSpan = 6;
+
+        col.append(this.attributesTable(semantic));
+        row.append(col);
+
+        this._table.append(row);
+    }
+
+    /**
+     * Only the required properties for a given semantic are shown in the initial table
+     * This is an expanded view of all the properties for a semantic, including a recursive call to their sub-properties
+     *
+     * @param semantic a single semantic field from the semantics.json
+     * @returns {HTMLTableElement}
+     */
+    attributesTable(semantic){
+        let table = document.createElement('table');
+        table.classList.add('nested-attributes');
+
+        for (const [att, val] of Object.entries(semantic)) {
+            // if(H5pcliSemanticsDocs.semanticBasicAttributes.includes(att)){continue;}
+            let tr = document.createElement('tr');
+            let nameRow = document.createElement('td');
+            let typeRow = document.createElement('td');
+            let valueRow = document.createElement('td');
+            tr.append(nameRow);
+            // tr.append(typeRow);
+            tr.append(valueRow);
+
+            let attUrl = this.attributeUrl(att);
+            if(attUrl){
+                nameRow.innerHTML = `<a href="${attUrl}" target="_blank">${att}</a>`;
+                let div = document.createElement('div');
+                div.innerHTML = "&#128269;";
+                div.classList.add('preview');
+                div.onclick = ()=>{this.toggleDocsFrame(div, attUrl)};
+                nameRow.append(div);
+            } else {
+                nameRow.textContent = att;
+            }
+
+            typeRow.innerHTML = typeof val;
+
+            if(typeof val === 'object' || typeof val === 'array'){
+                valueRow.append(this.attributesTable((val)));
+            } else {
+                valueRow.textContent = val;
+            }
+
+            table.append(tr);
+        }
+        return table;
+    }
+
+    /**
+     * Callback function for the documentation preview icon.
+     * If an documentation iframe is open it will be closed
+     *
+     * For the chosen property open a preview url to the h5p.org documentation site
+     *
+     * @param parent
+     * @param url
+     */
+    toggleDocsFrame(parent, url){
+        let oldAnchor = this.shadowRoot.querySelector('.anchor');
+        let iframe = this.shadowRoot.getElementById('docPreview');
+        if(iframe){
+            oldAnchor.classList.remove('anchor');
+            iframe.remove();
+        }
+
+        if(parent !== oldAnchor){
+            iframe = document.createElement('iframe');
+            iframe.src = url;
+            iframe.id = 'docPreview';
+            this._previewcontainer.append(iframe);
+            parent.classList.add('anchor');
+        }
+    }
+
+    /**
+     * Callback function for the Show All column
+     * Shows or hides the Attribute Table for the given semantic row
+     * @param id
+     * @param toggleId
+     */
+    toggleAttributes(id, toggleId){
+        let row = this.shadowRoot.getElementById(id);
+        let toggler = this.shadowRoot.getElementById(toggleId);
+        if (row.style.display === "none" || row.style.display === "") {
+            row.style.display = "table-row";
+            toggler.textContent = "Hide all";
+        } else {
+            row.style.display = "none";
+            toggler.textContent = "Show all";
+        }
+    }
+
+
+    /**
+     * URL helpers for documentation links
+     * These make sure the type/attribute/widget exist before return a URL
+     */
+
+
+    typeUrl(typeName){
+        if(H5pcliSemanticsDocs.semanticTypes.includes(typeName)){
+            return `${H5pcliSemanticsDocs.semanticsDocUrl}#type-${typeName}`;
+        } else {
+            return null;
+        }
+    }
+
+    attributeUrl(attName){
+        //todo check camelcase?
+        if(H5pcliSemanticsDocs.semanticAttributes.includes(attName)){
+            return `${H5pcliSemanticsDocs.semanticsDocUrl}#attribute-${attName}`;
+        } else {
+            return null;
+        }
+    }
+
+    widgetUrl(widgetName){
+        //todo check camelcase?
+        if(H5pcliSemanticsDocs.semanticWidgets.includes(widgetName)){
+            return `${H5pcliSemanticsDocs.semanticsDocUrl}#widget-${widgetName}`;
+        } else {
+            return null;
+        }
+    }
+
+
+
+}
+
+if( !customElements.get('h5pcli-semantics-docs')){
+    customElements.define('h5pcli-semantics-docs', H5pcliSemanticsDocs);
+}

--- a/assets/type_browser/components/h5pcli-semantics.js
+++ b/assets/type_browser/components/h5pcli-semantics.js
@@ -1,0 +1,125 @@
+/**
+ * Fetch an H5P Semantics JSON url and display in table form and JSON preview
+ * Will not fetch the URL until this element is visible on the page
+ * Uses the h5pcli-semantics-docs component for table display
+ *
+ * @attribute {string} src - URL to an H5P semantics JSON
+ *
+ * @slot viewer - The slot for the table displaying the semantics with h5pcli-semantics-docs
+ * @slot json - Slot for JSON preview
+ *
+ * @tagname h5pcli-semantics
+ *
+ * @example HTML Usage
+ * <h5pcli-semantics src="/library/type/semantics.json"></h5pcli-semantics>
+ *
+ * @example Javascript Instantiation
+ * let semantics = document.createElement('h5pcli-semantics');
+ * semantics.src = '/content_type/semantics_url.json';
+ * this.append(semantics);
+ *
+ */
+export default class H5pcliSemantics extends HTMLElement {
+    constructor() {
+        super();
+
+        let shadowRoot = this.attachShadow({ mode: 'open' });
+        shadowRoot.appendChild(H5pcliSemantics.template.content.cloneNode(true));
+
+        this._loaded = false;
+    }
+
+    static get template() {
+        let tmpl = document.createElement('template');
+        tmpl.innerHTML = `
+			<style>
+			</style>
+			<slot name="viewer">Loading documentation</slot>
+			<slot name="json">Loading json</slot>
+		`;
+        return tmpl;
+    }
+
+    /*
+    Use an IntersectionObserver to only fetch src when visible, then stop listening
+     */
+    connectedCallback() {
+        // delay fetching the until visible
+        const observer = new IntersectionObserver(
+            (entries) => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        if(this.src){
+                            this.fetchAndDisplay();
+                        }
+                        observer.unobserve(entry.target);
+                    }
+                });
+            },
+            {
+                root: this.parentNode
+            }
+        );
+
+        observer.observe(this);
+    }
+
+    get src() {
+        return this.getAttribute('src');
+    }
+    set src(val) {
+        this.setAttribute('src', val);
+    }
+
+    /*
+    After fetching json render in h5pcli-semantics-docs and display preview JSON
+     */
+    async fetchAndDisplay() {
+        if(this._loaded){return};
+        this._loaded = true;
+
+        let semanticsJson = await this.fetchSemantics();
+
+        let docs = document.createElement('h5pcli-semantics-docs');
+        docs.slot = "viewer";
+        await docs.parseSemantics(semanticsJson);
+        this.append(docs);
+
+        let details = document.createElement('details');
+        details.slot = "json";
+        let summary = document.createElement('summary');
+        summary.textContent = "Semantics JSON";
+        details.append(summary);
+        let pre = document.createElement('pre');
+        let code = document.createElement('code')
+        code.setAttribute("class", "language-json")
+        code.textContent = JSON.stringify(semanticsJson, undefined, 2)
+        details.append(pre);
+        pre.append(code);
+
+        this.append(details);
+
+        if(typeof hljs !== "undefined"){
+            try{hljs.highlightElement(code);} catch {console.log("hljs loaded, but failed to highlight xapi event.")}
+        }
+    }
+
+    async fetchSemantics() {
+        try {
+            const response = await fetch(this.src);
+            if (!response.ok) {
+                throw new Error(`Response status: ${response.status}`);
+            }
+
+            const json = await response.json();
+            return json;
+        } catch (error) {
+            console.error(error.message);
+        }
+    }
+
+}
+
+if( !customElements.get('h5pcli-semantics')){
+    customElements.define('h5pcli-semantics', H5pcliSemantics);
+}

--- a/assets/type_browser/components/h5pcli-type-browser.js
+++ b/assets/type_browser/components/h5pcli-type-browser.js
@@ -1,0 +1,216 @@
+/**
+ * Render a filterable index of H5P Content Types
+ * Each type is displayed as a h5pcli-type-browser
+ *
+ * Provides search for library titles and filtering for runnable/notrunnable types
+ *
+ * @attribute {string} src - Endpoint of Augmented Library JSON
+ *
+ * @slot library - Each library will be slotted into the light dom
+ *
+ * @tagname h5pcli-type-browser
+ *
+ * @example HTML Usage
+ * <h5pcli-type-browser src="/type_browser/installed_libraries"></h5pcli-type-browser>
+ *
+ */
+export default class H5pcliTypeBrowser extends HTMLElement {
+    static filteredClassName = 'filteredout';
+    //Filter localStorage keys
+    static runnableFilterState = "h5pcli-filter-runnable";
+    static notrunnableFilterState = "h5pcli-filter-notrunnable";
+    static showDependencyState = "h5pcli-filter-show-dependencies";
+    static searchState = "h5pcli-filter-search-value";
+
+    constructor() {
+        super();
+
+        let shadowRoot = this.attachShadow({ mode: 'open' });
+        shadowRoot.appendChild(H5pcliTypeBrowser.template.content.cloneNode(true));
+
+        this._searchInput = this.shadowRoot.querySelector('#search-input');
+        this._dependencyToggle = this.shadowRoot.querySelector('#include-dependencies');
+        this._runnableToggle = this.shadowRoot.querySelector('#runnable-toggle');
+        this._notrunnableToggle = this.shadowRoot.querySelector('#notrunnable-toggle');
+        this._slottedLibraries = [];
+        this.applyFilters = this.applyFilters.bind(this)
+    }
+
+    static get template() {
+        let tmpl = document.createElement('template');
+        tmpl.innerHTML = `
+			<style>
+			::slotted(.${H5pcliTypeBrowser.filteredClassName}){
+			    display: none !important;
+			}
+            #search-container {
+              display: grid;
+              grid-template-columns: 1fr auto auto;
+              gap: 10px;
+              margin-bottom: 10px;
+            }
+            #search-input {
+              grid-column: 1 / 2;
+              width: 100%;
+              padding: 8px;
+              box-sizing: border-box;
+            }
+            #search-options {
+              grid-column: 1 / 4;
+              display: flex;
+              gap: 15px;
+              align-items: center;
+              margin-top: 5px;
+            }
+            .filters {
+              display: flex;
+              align-items: center;
+              gap: 5px;
+            }
+			</style>
+			
+			<div id="search-container">
+                <input type="text" id="search-input" placeholder="Search libraries...">
+
+                <div id="search-options">
+                    <div>
+                        <input type="checkbox" id="include-dependencies">
+                        <label for="include-dependencies">Include Dependencies</label>
+                    </div>
+            
+                    <div class="filters">
+                        <span class="section-label">Filters:</span>
+                        <div>
+                            <input type="checkbox" id="runnable-toggle" checked>
+                            <label for="runnable-toggle">Show Runnable</label>
+                        </div>
+                        <div>
+                            <input type="checkbox" id="notrunnable-toggle">
+                            <label for="notrunnable-toggle">Show not-runnable</label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+			
+
+			<slot name="library">Loading...</slot>
+		`;
+        return tmpl;
+    }
+
+    connectedCallback() {
+        this.restoreFilterState();
+        [this._runnableToggle, this._notrunnableToggle, this._dependencyToggle, this._searchInput].forEach((elem) =>{
+            elem.addEventListener(elem.type === 'text' ? 'input' : 'change', (e)=>{
+                this.saveFilterState();
+                this.applyFilters();
+            });
+        });
+    }
+    disconnectedCallback(){
+        [this._runnableToggle, this._notrunnableToggle, this._dependencyToggle, this._searchInput].forEach((elem) =>{
+            elem.removeAllListeners();
+        });
+    }
+
+    /*
+    Set visible libraries for current search and filter options
+     */
+    async applyFilters(){
+        let searchVal = this._searchInput.value;
+
+        this._slottedLibraries.forEach((lib) => {
+            let visible = false;
+
+            if(lib.isRunnable()){
+                visible = this._runnableToggle.checked;
+            } else {
+                visible = this._notrunnableToggle.checked;
+            }
+
+            // it wasn't filtered out, do search string
+            if(visible && searchVal.length > 0){
+                visible = lib.matchesSearch(searchVal, this._dependencyToggle.checked);
+            }
+
+            if(visible){
+                lib.classList.remove(H5pcliTypeBrowser.filteredClassName);
+            } else {
+                lib.classList.add(H5pcliTypeBrowser.filteredClassName);
+            }
+        });
+    }
+
+    saveFilterState(){
+        localStorage.setItem(H5pcliTypeBrowser.runnableFilterState, this._runnableToggle.checked);
+        localStorage.setItem(H5pcliTypeBrowser.notrunnableFilterState, this._notrunnableToggle.checked);
+        localStorage.setItem(H5pcliTypeBrowser.showDependencyState, this._dependencyToggle.checked);
+        localStorage.setItem(H5pcliTypeBrowser.searchState, this._searchInput.value);
+    }
+
+    restoreFilterState(){
+        this._runnableToggle.checked = JSON.parse(localStorage.getItem(H5pcliTypeBrowser.runnableFilterState)) ?? true;
+        this._notrunnableToggle.checked = JSON.parse(localStorage.getItem(H5pcliTypeBrowser.notrunnableFilterState)) ?? false;
+        this._dependencyToggle.checked = JSON.parse(localStorage.getItem(H5pcliTypeBrowser.showDependencyState)) ?? false;
+        this._searchInput.value = localStorage.getItem(H5pcliTypeBrowser.searchState) ?? "";
+    }
+
+    // Invoked when component attribute changes
+    attributeChangedCallback(attrName, oldVal, newVal) {
+        if (attrName === 'src') {
+            this.fetchAndListLibraries();
+        }
+    }
+
+    static get observedAttributes() {
+        return ['src'];
+    }
+
+    get src() {
+        return this.getAttribute('src');
+    }
+    set src(val) {
+        this.setAttribute('src', val);
+    }
+
+
+    /*
+    Add a collapsed h5pcli-content-type for each library to the library slot
+     */
+    async fetchAndListLibraries() {
+        if(!customElements.get('h5pcli-content-type')) throw("Required component h5pcli-content-type not loaded");
+
+        let res = await this.fetchLibraries();
+
+        for (const [name, lib] of Object.entries(res)) {
+            let type = document.createElement('h5pcli-content-type');
+            type.setAttribute("class", "item");
+            type.setAttribute("collapsed", "");
+            type.slot = "library";
+            type.renderFromAugmentedLibrary(lib);
+            this.append(type);
+        }
+
+        this._slottedLibraries = this.shadowRoot.querySelector('slot[name="library"]').assignedElements({ flatten: true });
+        this.applyFilters();
+    }
+
+    async fetchLibraries() {
+        try {
+            const response = await fetch(this.src);
+            if (!response.ok) {
+                throw new Error(`Response status: ${response.status}`);
+            }
+
+            const json = await response.json();
+            return json;
+        } catch (error) {
+            console.error(error.message);
+        }
+    }
+
+}
+
+if( !customElements.get('h5pcli-type-browser')){
+    customElements.define('h5pcli-type-browser', H5pcliTypeBrowser);
+}

--- a/assets/type_browser/components/h5pcli-xapi-examples.js
+++ b/assets/type_browser/components/h5pcli-xapi-examples.js
@@ -1,0 +1,112 @@
+/**
+ * A wrapper component for h5pcli-xapi-viewer to populate it pre-saved xAPI examples
+ * It will defer fetching the events until visible, and disables the h5pcli-xapi-viewer instance from listening for new events
+ *
+ * @attribute {string} src - The optional API endpoint that returns an array of example xAPI events. Fetching events is deferred until the element is visible.
+ *
+ * @slot viewer - The slot for the h5pcli-xapi-viewer which will be added with the attributes: open, nolisten
+ *
+ * @tag h5pcli-xapi-examples
+ * @tagname h5pcli-xapi-examples
+ *
+ * @example HTML Usage
+ * <h5pcli-xapi-examples src="./examples.json"></h5pcli-xapi-examples>
+ *
+ * @example Javascript Instantiation
+ * let examples = document.createElement('h5pcli-xapi-examples');
+ * examples.src = "./examples.json";
+ * this.append(examples);
+ */
+export default class H5pcliXapiExamples extends HTMLElement {
+    constructor() {
+        super();
+
+        let shadowRoot = this.attachShadow({ mode: 'open' });
+        shadowRoot.appendChild(H5pcliXapiExamples.template.content.cloneNode(true));
+
+        this._loaded = false;
+    }
+
+    static get template() {
+        let tmpl = document.createElement('template');
+        tmpl.innerHTML = `
+			<style>
+			</style>
+			<slot name="viewer">Loading...</slot>
+		`;
+        return tmpl;
+    }
+
+    /*
+    * Use an IntersectionObserver to detect when the element is visible
+    * once visible, it will stop observing and asynchronously fetch and load the src data
+    */
+    connectedCallback() {
+        // delay fetching the xapi events until visible
+        const observer = new IntersectionObserver(
+            (entries) => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        if(this.src){
+                            this.fetchAndListEvents();
+                        }
+                        observer.unobserve(entry.target);
+                    }
+                });
+            },
+            {
+                root: this.parentNode
+            }
+        );
+
+        observer.observe(this);
+    }
+
+    get src() {
+        return this.getAttribute('src');
+    }
+    set src(val) {
+        this.setAttribute('src', val);
+    }
+
+    /*
+    * If the h5pcli-xapi-viewer element exists, fetch the src data and populate that component
+    * with all the xAPI events from the src call.
+    * The h5pcli-xapi-viewer element is set to nolisten mode.
+    */
+    async fetchAndListEvents() {
+        if(!customElements.get('h5pcli-xapi-viewer')) throw("Required component h5pcli-xapi-viewer not loaded");
+        if(this._loaded){return};
+        this._loaded = true;
+
+        let res = await this.fetchEvents();
+        let viewer = document.createElement('h5pcli-xapi-viewer');
+        viewer.slot = "viewer";
+        viewer.setAttribute("nolisten", "nolisten");
+        viewer.setAttribute("open", "open");
+        this.append(viewer);
+
+        for (const event of res['xapiExamples']) {
+            viewer.createSummaryAndAdd(event);
+        }
+    }
+
+    async fetchEvents() {
+        try {
+            const response = await fetch(this.src);
+            if (!response.ok) {
+                throw new Error(`Response status: ${response.status}`);
+            }
+
+            const json = await response.json();
+            return json;
+        } catch (error) {
+            console.error(error.message);
+        }
+    }
+
+}
+
+if( !customElements.get('h5pcli-xapi-examples')){
+    customElements.define('h5pcli-xapi-examples', H5pcliXapiExamples);
+}

--- a/assets/type_browser/components/h5pcli-xapi-viewer.js
+++ b/assets/type_browser/components/h5pcli-xapi-viewer.js
@@ -1,0 +1,210 @@
+/**
+ * Display xAPI events in collapsed details nodes
+ * Each event is displayed with a human-readable summary for  {actor} {action} {object}
+ *
+ * If in listen mode (default): Listen for xAPI events from the H5P.externalDispatcher and render on page
+ * If in nolisten mode: Only display xAPI events
+ *
+ * @attribute {bool} open - The list of captured events is closed by default, adding this attribute will start it open
+ * @attribute {bool} float - Enable the list renders _over_ the surrounding content
+ * @attribute {bool} nolisten - Don't listen for H5P events, they can still be added manually
+ *
+ * @slot events - Slot for added events
+ *
+ * @example HTML Usage - Capture events on an H5P View page and when expanded, float content over page
+ * <h5pcli-xapi-viewer float></h5pcli-xapi-viewer>
+ *
+ * @example Javascript Instantiation with existing list of events
+ * let viewer = document.createElement('h5pcli-xapi-viewer');
+ * viewer.setAttribute("nolisten", "nolisten");
+ * viewer.setAttribute("open", "open");
+ * this.append(viewer);
+ *
+ * for (const event of xAPIJsonExamplesArray) {
+ *     viewer.createSummaryAndAdd(event);
+ * }
+ *
+ * @tag h5pcli-xapi-viewer
+ * @tagname h5pcli-xapi-viewer
+ */
+export default class H5pcliXapiViewer extends HTMLElement {
+    static get observedAttributes() {
+        return ["open", "float", "nolisten"];
+    }
+
+    constructor() {
+        super();
+
+        let shadowRoot = this.attachShadow({ mode: 'open' });
+        shadowRoot.appendChild(H5pcliXapiViewer.template.content.cloneNode(true));
+
+        this._summary = this.shadowRoot.querySelector('summary');
+        this._list = this.shadowRoot.querySelector('.list');
+        this._content = this.shadowRoot.querySelector('.content');
+
+        this._listening = false;
+
+        this.preProcessEvent = this.preProcessEvent.bind(this)
+    }
+
+    static get template() {
+        let tmpl = document.createElement('template');
+        tmpl.innerHTML = `
+			<style>
+			    .list {
+                  padding: 10px; 
+                  /*background-color: #e2e5ee;*/
+                  border: 1px solid #e2e5ee;
+                  border-radius: 3px;
+                }
+                .list .content{
+                    width: 100%;
+                    padding: 1em;
+                    max-height: 80vh;
+                    overflow: auto;
+                }
+                .float{
+                    position: absolute;
+                    background-color: black;
+                }
+                :host([open]) > .list[open] > summary{
+                  list-style: none;
+                }
+                :host([open]) > .list:not(open) > summary{
+                  list-style: revert;
+                }
+                ::slotted(.slotted-details){
+                    padding: 5px !important;
+                    font-family: monospace !important;
+                    font-size: x-large !important;
+                    cursor: pointer;
+                }
+			</style>
+			<details class="list">
+              <summary>xAPI Events</summary>
+              <div class="content">
+                <slot name="events"></slot>
+              </div>
+            </details>
+            
+		`;
+        return tmpl;
+    }
+
+    connectedCallback() {
+        this.setXapiListener();
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if(name === "open"){
+            if(newValue === null){
+                this._list.removeAttribute("open");
+            } else {
+                this._list.setAttribute("open", 'open');
+            }
+        }
+        if(name === "float"){
+            if(newValue === null){
+                this._content.classList.remove("float");
+            } else {
+                this._content.classList.add("float");
+            }
+        }
+        if(name === "nolisten"){
+            this.setXapiListener();
+        }
+
+    }
+
+    setXapiListener(){
+        if(!this.hasAttribute("nolisten") && typeof H5P !== 'undefined'){
+            H5P.externalDispatcher.on('xAPI', this.preProcessEvent);
+        } else if (typeof H5P !== 'undefined') {
+            H5P.externalDispatcher.off('xAPI', this.preProcessEvent);
+        }
+    }
+
+    preProcessEvent(event){
+        this.createSummaryAndAdd(event.data.statement);
+    }
+
+    /**
+     * Create a human-readable summary for {actor} {action} {object} {score/result summary}
+     * @param statement
+     */
+    createSummaryAndAdd(statement) {
+        let summary = "Example Event";
+        try {
+            let user = statement.actor.name;
+            let verb = statement.verb.id.split('/').pop();
+            let object = statement.object.id.split('/').pop();
+            let result = '';
+
+            if (statement.object.definition?.name?.['en-US']) {
+                object = statement.object.definition.name['en-US'];
+            }
+
+            if (statement.result) {
+                let res = statement.result;
+                if("success" in res){
+                    result = res.success ? "correct" : "incorrect";
+                }
+                if(res.score){
+                    result += ` (${res.score.raw}/${res.score.max})`;
+                }
+                if(result){
+                    result = ` - (${result})`;
+                }
+            }
+
+            summary = `${user} "${verb}" ${object} ${result}`;
+        } catch (e) {
+            console.log("Error creating summary for event. ", e, statement);
+        }
+        this.addEvent(summary, statement);
+    }
+
+    /**
+     * Add the given short summary with a collapsed details node of the actual xAPI JSON object
+     *
+     * @param shortStatement
+     * @param jsonStringOrObj
+     */
+    addEvent(shortStatement, jsonStringOrObj){
+        if(!jsonStringOrObj){return;}
+        let json_parsed;
+
+        try{
+            json_parsed = (typeof jsonStringOrObj === 'string') ? JSON.parse(jsonStringOrObj) : jsonStringOrObj;
+        } catch(err) {
+            console.log("Error parsing json", err, json_parsed)
+            return;
+        }
+
+        let details = document.createElement('details')
+        details.slot = "events";
+        details.setAttribute("class", "slotted-details")
+        let summary = document.createElement('summary')
+        summary.textContent = shortStatement;
+        details.append(summary);
+        let pre = document.createElement('pre');
+        let code = document.createElement('code')
+        code.setAttribute("class", "language-json")
+        code.textContent = JSON.stringify(json_parsed, undefined, 2)
+        pre.append(code);
+
+        details.append(pre)
+        this.append(details);
+
+        if(typeof hljs !== "undefined"){
+            try{hljs.highlightElement(code);} catch {console.log("hljs loaded, but failed to highlight xapi event.")}
+        }
+
+        let count = this.querySelectorAll("details").length;
+        this._summary.textContent = `xAPI Events (${count})`
+    }
+}
+
+if( !customElements.get("h5pcli-xapi-viewer")){
+    customElements.define('h5pcli-xapi-viewer', H5pcliXapiViewer);
+}

--- a/assets/type_browser/components/index.js
+++ b/assets/type_browser/components/index.js
@@ -1,0 +1,7 @@
+import "./h5pcli-content-type.js";
+import "./h5pcli-xapi-viewer.js";
+import "./h5pcli-xapi-examples.js";
+import "./h5pcli-semantics.js";
+import "./h5pcli-semantics-docs.js";
+import "./h5pcli-library-overview.js";
+import "./h5pcli-type-browser.js";

--- a/assets/type_browser/components/tabs.css
+++ b/assets/type_browser/components/tabs.css
@@ -1,0 +1,35 @@
+h5pcli-content-type > details {
+    display: contents;
+}
+
+h5pcli-content-type > details > summary {
+    display: flex;
+    justify-content: center;
+    grid-row: 1;
+    cursor: pointer;
+    border: 1px solid #ccc;
+    /*border-bottom: none;*/
+    padding: 4px;
+}
+
+h5pcli-content-type > details > div {
+    border: 1px solid #ccc;
+    padding: 1rem;
+    grid-column: 1 / -1;
+    position: sticky;
+    left: 0;
+    border-radius: 0 0 4px 4px;
+}
+
+h5pcli-content-type > details[open]::details-content {
+    display: contents;
+}
+
+h5pcli-content-type > details[open] > summary {
+    font-weight: bold;
+}
+
+h5pcli-content-type[collapsed] > details > div {
+    /*max-height: 500px;*/
+    overflow: auto;
+}

--- a/assets/type_browser/content_type.html
+++ b/assets/type_browser/content_type.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{lang_installed_libraries}</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" type="text/css" href="/assets/styles/reset.css">
+    <link rel="stylesheet" type="text/css" href="/assets/styles/style.css">
+    <link rel="stylesheet" href="/type_browser/components/tabs.css">
+
+    <script type="module" src="/type_browser/components/index.js"></script>
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <style>
+        .item{
+            display: unset;
+        }
+    </style>
+</head>
+<body>
+<div class="sticky">
+    <div class="menu-holder">
+        <div class="menu">
+            <div class="button dashboard" id="newContentButton">
+                <a href="/dashboard">{lang_dashboard}</a>
+            </div>
+            <a href="/type_browser/" class="button type-browser" id="typeBrowserButton">
+                <span class="button-label">{lang_installed_libraries}</span>
+            </a>
+        </div>
+    </div>
+</div>
+
+<div class="holder content" id="content">
+    <h5pcli-content-type class="item" src="./library.json"></h5pcli-content-type>
+</div>
+</body>
+</html>

--- a/assets/type_browser/index.html
+++ b/assets/type_browser/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{lang_installed_libraries}</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" type="text/css" href="/assets/styles/reset.css">
+    <link rel="stylesheet" type="text/css" href="/assets/styles/style.css">
+    <link rel="stylesheet" href="/type_browser/components/tabs.css">
+
+    <script type="module" src="/type_browser/components/index.js"></script>
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <style>
+        .item{
+            display: block;
+        }
+    </style>
+</head>
+<body>
+<div class="sticky">
+    <div class="menu-holder">
+        <div class="menu">
+            <div class="button dashboard" id="newContentButton">
+                <a href="/dashboard">{lang_dashboard}</a>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+<div class="holder content" id="content">
+    <h5pcli-type-browser src="/type_browser/installed_libraries"></h5pcli-type-browser>
+</div>
+</body>
+</html>

--- a/src/server/apis/typeBrowser.js
+++ b/src/server/apis/typeBrowser.js
@@ -1,0 +1,182 @@
+const fs = require('fs');
+const path = require('path');
+const logic = require('../../../logic.js');
+const config = require('../../../configLoader.js');
+const userSession = require('../user_session.js');
+
+const xapiExamplesDir = "events/xapi/examples";
+// Default data links to locate
+const linksData = {semantics: "semantics.json", };
+
+/**
+ * Render the /type_browser/index.html page with translations
+ *
+ * @route   GET /type_browser
+ */
+async function typeBrowserIndex(request, response, next) {
+    try {
+        userSession.updateFromQuery(request);
+        const html = fs.readFileSync(`${require.main.path}/${config.folders.assets}/type_browser/index.html`, 'utf-8');
+        const labels = await userSession.getLangLabels();
+        response.set('Content-Type', 'text/html');
+        response.end(logic.fromTemplate(html, labels));
+    } catch (error) {
+        handleError(error, response);
+    }
+}
+
+/**
+ *  Return list of Augmented H5P Library objects that include links
+ *
+ * @route   GET /type_browser/installed_libraries
+ */
+async function installedLibraries(request, response, next) {
+    try {
+        const out = await fullLibraries();
+
+        response.set('Content-Type', 'application/json');
+        response.end(JSON.stringify(out));
+    } catch (error) {
+        handleError(error, response);
+    }
+}
+
+/**
+ * Renders a content page for displaying details about a Library
+ *
+ * @route GET /type_browser/:library
+ * @param request.library
+ */
+async function contentType(request, response, next) {
+    try {
+        userSession.updateFromQuery(request);
+        const html = fs.readFileSync(`${require.main.path}/${config.folders.assets}/type_browser/content_type.html`, 'utf-8');
+        const labels = await userSession.getLangLabels();
+        response.set('Content-Type', 'text/html');
+        response.end(logic.fromTemplate(html, labels));
+    } catch (error) {
+        handleError(error, response);
+    }
+}
+
+/**
+ * Returns the Augmented Library JSON object for the specified :library
+ *
+ * @route /type_browser/:library/library.json
+ * @param request.library
+ */
+async function contentTypeLibrary(request, response, next){
+    const out = await singleLibrary(request.params.library);
+
+    response.set('Content-Type', 'application/json');
+    response.end(JSON.stringify(out));
+}
+
+/**
+ * If the specified :library has example xAPI events in events/xapi/examples return them in a JSON array
+ *
+ * @route /type_browser/:library/xapi_examples
+ * @param request.library
+ */
+async function xapiEventsForType(request, response, next){
+    const out = {xapiExamples: []};
+
+    let xapiDir = path.join(config.folders.libraries, request.params.library, xapiExamplesDir)
+    if(fs.existsSync(xapiDir)){
+        const files = fs.readdirSync(xapiDir);
+        const jsonFiles = files.filter(el => path.extname(el) === '.json')
+        for (let file of jsonFiles) {
+            out['xapiExamples'].push(await logic.getFile(path.join(xapiDir, file), true));
+        }
+    }
+
+    response.set('Content-Type', 'application/json');
+    response.end(JSON.stringify(out));
+}
+
+module.exports = {contentType, contentTypeLibrary, installedLibraries, typeBrowserIndex, xapiEventsForType}
+
+
+/*
+Helper functions
+ */
+
+/**
+ * Using the registry list, iterate all local libraries and generate a list of Augmented Library JSON
+ */
+async function fullLibraries()  {
+    let registry = await logic.getRegistry();
+    registry = registry.regular;
+    const output = {};
+    const dirs = fs.readdirSync(config.folders.libraries);
+    for (let folder of dirs) {
+        let lib = await fullLibrary(folder, registry);
+        if(lib) output[lib.library.machineName] = lib;
+    }
+    return output;
+}
+
+/**
+ * Generate an Augmented Library JSON for the specified Library
+ * @param libraryFolder
+ * @returns {Promise<undefined|{links_data: {library: string}, icon_url: null, links_web: {docPage: string}, library: null}>}
+ */
+async function singleLibrary(libraryFolder){
+    let registry = await logic.getRegistry();
+    registry = registry.regular;
+
+    return await fullLibrary(libraryFolder, registry);
+}
+
+/**
+ * Generate an Augmented Library JSON for the specified Library
+ * @param folderName
+ * @param registry
+ * @returns {Promise<{links_data: {library: string}, icon_url: null, links_web: {docPage: string}, library: null}>}
+ */
+async function fullLibrary(folderName, registry) {
+    let folder = path.join(config.folders.libraries, folderName);
+    const libraryFile = path.join(folder, "library.json");
+    if (!fs.existsSync(libraryFile)) {
+        return;
+    }
+
+    let out = {
+        links_data: {library: path.join("/", libraryFile)},
+        links_web: {docPage: `/type_browser/${folderName}/`},
+        icon_url: null,
+        library: null,
+    }
+
+    out.library = await logic.getFile(libraryFile, true);
+
+    const id = out.library.machineName;
+    if (registry[id]) {
+        out.library["repoName"] = registry[id]["repoName"];
+        out.library["org"] = registry[id]["org"];
+        out.library["shortName"] = registry[id]["shortName"];
+    }
+
+    let iconPath = path.join(folder, "icon.svg")
+    if (fs.existsSync(iconPath)) out.icon_url = path.join("/", iconPath);
+
+    let xapiPath = path.join(folder, xapiExamplesDir)
+    if(fs.existsSync(xapiPath)){
+        out.links_data['xapi_examples'] = `/type_browser/${folderName}/xapi_examples`;
+    }
+
+    for (const [key, file] of Object.entries(linksData)) {
+        const localPath = path.join(folder, file);
+        if (fs.existsSync(localPath)) out.links_data[key] = path.join("/", localPath);
+    }
+
+    return out;
+}
+
+
+// Helpers copied from ../api.js, find way to reuse?
+const handleError = (error, response) => {
+    console.log(error);
+    response.set('Content-Type', 'application/json');
+    response.end(JSON.stringify({ error: error.toString() }));
+}

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -2,11 +2,14 @@ const express = require('express');
 const config = require('../../configLoader.js');
 const multer = require('multer')({ dest: `./${config.folders.temp}` });
 const api = require('./api.js');
+const typeBrowser = require('./apis/typeBrowser.js');
 let app = express();
 app.use(express.json());
 app.use(express.urlencoded({
   extended: true
 }));
+
+// Dashboard & CMS
 app.get('/', (req, res) => res.redirect('/dashboard'));
 app.get('/favicon.ico', api.favicon);
 app.get('/dashboard', api.dashboard);
@@ -16,18 +19,36 @@ app.get('/export/:library/:folder', api.export);
 app.post('/import/:folder', multer.single('file'), api.import);
 app.post('/create/:type/:folder', api.create);
 app.post('/remove/:folder', api.remove);
-app.get('/split/:library/:folder', api.splitView);
+
+// View
 app.get('/view/:library/:folder', api.view);
+app.get('/split/:library/:folder', api.splitView);
+
+// Editing
 app.get('/edit/:library/:folder/libraries', api.ajaxLibraries);
 app.post('/edit/:library/:folder/translations', api.ajaxTranslations);
 app.get('/edit/:library/:folder', api.edit);
 app.post('/edit/:library/:folder/libraries', api.ajaxLibraries);
 app.post('/edit/:library/:folder/files', multer.single('file'), api.uploadFile);
 app.post('/edit/:library/:folder', multer.none(), api.saveContent);
+
+// Content Sessions
 app.get('/content-user-data/:folder/:type/:id', api.getUserData);
 app.post('/content-user-data/:folder/:type/:id', api.setUserData);
 app.delete('/content-user-data/:folder', api.resetUserData);
+
+// Serve assets dir
 app.use(`/${config.folders.assets}`, express.static(`${require.main.path}/${config.folders.assets}`))
+
+// Content Type Browser
+app.get('/type_browser/installed_libraries', typeBrowser.installedLibraries);
+app.get('/type_browser/:library/xapi_examples', typeBrowser.xapiEventsForType);
+app.get('/type_browser/:library/library.json', typeBrowser.contentTypeLibrary);
+app.get('/type_browser/:library', typeBrowser.contentType);
+app.get('/type_browser', typeBrowser.typeBrowserIndex);
+app.use(`/type_browser`, express.static(`${require.main.path}/${config.folders.assets}/type_browser/`))
+
+// Everything else will serve statically from the working directory where `h5p server` is running:
 app.use(express.static('./'));
 
 let port = config.port;


### PR DESCRIPTION
Adds a page to browse installed libraries, depends on the [API refactor PR](https://github.com/h5p/h5p-cli/pull/165)
See attached video for functionality.

I need something like this for myself to more easily understand Libraries when working on them and I thought others would benefit as well if interested.

This PR adds:
- `src/server/apis/typeBrowser.js` - new API endpoints for the Type Browser UI
  - This mostly reuses helpers from `logic.js`
- `assets/type_browser/*` - Two pages for the browser index and viewing an individual library
- `assets/type_browser/components` - The components used in the browser
  - The bulk of the lines in the PR are these components, they are fairly well composed viewers for each part of a Library
 

https://github.com/user-attachments/assets/60cd33c6-c7a8-461d-a0d8-2e04b76b135e


The components all work together and the index ends up with a structure like:
```html
<h5pcli-type-browser src="/type_browser/installed_libraries">
    <h5pcli-content-type collapsed>
        <h5pcli-library-overview></h5pcli-library-overview>
        <h5pcli-semantics src="/libraries/H5P.TrueFalse-1.8/semantics.json"></h5pcli-semantics>
        <h5pcli-xapi-examples src="/type_browser/H5P.TrueFalse-1.8/xapi_examples">
            <h5pcli-xapi-viewer slot="viewer"></h5pcli-xapi-viewer>
        </h5pcli-xapi-examples>
    </h5pcli-content-type>
    <!--  repeated for each content type  -->
</h5pcli-type-browser>
```

