### PR TITLE
HFP-4324 Fix: Ignore optional dependencies when creating content

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -529,7 +529,7 @@ module.exports = {
     const map = {};
     const preloadedDependencies = [];
     for (let item in libs) {
-      for (let predep of libs[item].preloadedDependencies) {
+      for (let predep of (libs[item].preloadedDependencies || [])) {
         if (map[predep.machineName]) {
           continue;
         }


### PR DESCRIPTION
When merged in, will set missing `preloadedDepencies` property to an empty array to prevent a crash when trying to create new content while _optional_ dependencies are missing.

I'd consider this a temporary fix. The underlying issue is probably linked to [HFP-4253](https://h5ptechnology.atlassian.net/browse/HFP-4253) that treats optional dependencies like mandatory dependencies.

[HFP-4253]: https://h5ptechnology.atlassian.net/browse/HFP-4253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ