### PR TITLE
HFP-4347 Fix timing dependent failure of theme controls init

### DIFF
--- a/assets/templates/view.html
+++ b/assets/templates/view.html
@@ -429,9 +429,14 @@
       }
       else {
         waitForH5P(() => {
-          innerWindow.H5P.externalDispatcher.on('initialized', () => {
+          if (innerWindow.H5P.instances?.length) {
             initializeThemeControls();
-          });
+          }
+          else {
+            innerWindow.H5P.externalDispatcher.on('initialized', () => {
+              initializeThemeControls();
+            });
+          }
         });
       }
     }


### PR DESCRIPTION
When merged in, will prevent failing to initialize the theme controls in cases where the `initialized` event was sent in the 100ms gap between two checks of `waitForH5P` function.