### PR TITLE
HFP-4354 Fix trying to access shortname of unregistered library

### DIFF
--- a/api.js
+++ b/api.js
@@ -797,8 +797,11 @@ const ajaxLibraries = async (options) => {
     }
   }
   if (options.machineName) {
-    libraries = [];
-    libraries.push(registry.reversed[options.machineName].shortName);
+    const entry = registry.reversed[options.machineName];
+    if (entry && libraryDirs[options.machineName]) {
+      libraries = [];
+      libraries.push(entry.shortName);
+    }
   }
   const toDo = [];
   for (let item of libraries) {


### PR DESCRIPTION
When merged in, will fix a crash when trying to load a library that was not registered with H5P CLI and thus has no shortname set.