### PR TITLE
H5PT-227 Add optional branch arg to setup

### DIFF
--- a/assets/docs/commands.md
+++ b/assets/docs/commands.md
@@ -51,7 +51,7 @@ Use `view` or `edit` for `<mode>`.
 Use `view` or `edit` for `<mode>`.  
 
 • `h5p setup <library|repoUrl> [ref] [download]` sets up a library and its dependencies.  
-`[ref]` is an optional git tag or branch for the library under test. Dependency versions are read from that ref's `library.json`; only the library itself is cloned at `[ref]` — its dependencies install at their normal versions from that tree.  
+`[ref]` is an optional git tag or branch for the library under test. Dependency versions are read from that ref's `library.json`; only the library itself is cloned at `[ref]`. Dependencies are cloned at those versions when the git tag exists, otherwise they fall back to master (with a warning).  
 For example, `h5p setup h5p-accordion 1.0.0` installs from tag "1.0.0", and `h5p setup h5p-accordion feat/example` installs from branch "feat/example".  
 `<repoUrl>` is a github repository url. Running the command in this format will also update the library in the local registry. This is useful for unregistered libraries.  
 For example, `h5p setup git@github.com:h5p/h5p-accordion.git` installs the "h5p-accordion" library and its dependencies. It also updates its entry in the local library registry.  

--- a/assets/docs/commands.md
+++ b/assets/docs/commands.md
@@ -50,7 +50,9 @@ Use `view` or `edit` for `<mode>`.
 • `h5p install <library> <mode>` downloads the library and its dependencies in the libraries folder.  
 Use `view` or `edit` for `<mode>`.  
 
-• `h5p setup <library|repoUrl> [version] [download]` sets up a library and its dependencies.  
+• `h5p setup <library|repoUrl> [version] [download] [branch]` sets up a library and its dependencies.  
+Use `[branch]` to set up the library from a specific git branch. Only the library itself follows the branch; its dependencies are resolved as usual and the library is cloned even if `[download]` is set.  
+For example, `h5p setup h5p-accordion '' '' fix/example` installs "h5p-accordion" from its "fix/example" branch.  
 `<repoUrl>` is a github repository url. Running the command in this format will also update the library in the local registry. This is useful for unregistered libraries.  
 For example, `h5p setup git@github.com:h5p/h5p-accordion.git` installs the "h5p-accordion" library and its dependencies. It also updates its entry in the local library registry.  
 You can optionally specify a library `[version]`. To view current versions for a library use the `tags` command.

--- a/assets/docs/commands.md
+++ b/assets/docs/commands.md
@@ -50,17 +50,17 @@ Use `view` or `edit` for `<mode>`.
 • `h5p install <library> <mode>` downloads the library and its dependencies in the libraries folder.  
 Use `view` or `edit` for `<mode>`.  
 
-• `h5p setup <library|repoUrl> [version] [download] [branch]` sets up a library and its dependencies.  
-Use `[branch]` to set up the library from a specific git branch. Only the library itself follows the branch; its dependencies are resolved as usual and the library is cloned even if `[download]` is set.  
-For example, `h5p setup h5p-accordion '' '' fix/example` installs "h5p-accordion" from its "fix/example" branch.  
+• `h5p setup <library|repoUrl> [ref] [download]` sets up a library and its dependencies.  
+`[ref]` is an optional git tag or branch for the library under test. Dependency versions are read from that ref's `library.json`; only the library itself is cloned at `[ref]` — its dependencies install at their normal versions from that tree.  
+For example, `h5p setup h5p-accordion 1.0.0` installs from tag "1.0.0", and `h5p setup h5p-accordion feat/example` installs from branch "feat/example".  
 `<repoUrl>` is a github repository url. Running the command in this format will also update the library in the local registry. This is useful for unregistered libraries.  
 For example, `h5p setup git@github.com:h5p/h5p-accordion.git` installs the "h5p-accordion" library and its dependencies. It also updates its entry in the local library registry.  
-You can optionally specify a library `[version]`. To view current versions for a library use the `tags` command.
-Using `1` for the `[download]` parameter will download the libraries instead of cloning them as git repos.  
+To view current tags for a library use the `tags` command.  
+Using `1` for the `[download]` parameter will download the libraries instead of cloning them as git repos. The library under test is still cloned when `[ref]` is a branch.  
 Set the `H5P_NO_UPDATES` environment variable to `1` to skip updating libraries and speed up the setup process.  
 Set the `H5P_SSH_CLONE` environment variable to `1` so that ssh urls are used when cloning private repositories. This is useful for cloning private repos and for when you want to commit from the `libraries/<library>` folder.  
 > [!IMPORTANT]
-> If no `[version]` is specified master branches will be used.  
+> If no `[ref]` is specified master branches will be used.  
 
 • `h5p missing <library>` will compute the unregistered dependencies for a library.  
 The library itself has to exist in the local library registry.  

--- a/cli.js
+++ b/cli.js
@@ -187,7 +187,7 @@ const cli = {
     }
   },
   // computes & installs dependencies for h5p library
-  setup: async function(library, version, download) {
+  setup: async function(library, version, download, branch) {
     const isUrl = ['http', 'git@'].includes(library.slice(0, 4)) ? true : false;
     const url = library;
     const missingOptionals = {};
@@ -195,6 +195,11 @@ const cli = {
       if (isUrl) {
         const entry = await this.register(url);
         library = logic.machineToShort(Object.keys(entry)[0]);
+      }
+      // branch is interpolated into a git clone shell command, so reject unsafe refs
+      if (branch && !/^[\w./-]+$/.test(branch)) {
+        console.log(`> error: invalid branch name "${branch}"`);
+        return;
       }
       let toSkip = [];
       const action = parseInt(download) ? 'download' : 'clone';
@@ -217,9 +222,9 @@ const cli = {
       }
       toSkip = [];
       console.log(`> ${action} ${library} library "view" dependencies into "${config.folders.libraries}" folder`);
-      toSkip = await logic.getWithDependencies(action, library, 'view', latest, toSkip);
+      toSkip = await logic.getWithDependencies(action, library, 'view', latest, toSkip, branch);
       console.log(`> ${action} ${library} library "edit" dependencies into "${config.folders.libraries}" folder`);
-      toSkip = await logic.getWithDependencies(action, library, 'edit', latest, toSkip);
+      toSkip = await logic.getWithDependencies(action, library, 'edit', latest, toSkip, branch);
       if (Object.keys(missingOptionals).length) {
         console.log('!!! missing optional libraries');
         for (let item in missingOptionals) {

--- a/cli.js
+++ b/cli.js
@@ -187,7 +187,8 @@ const cli = {
     }
   },
   // computes & installs dependencies for h5p library
-  setup: async function(library, version, download, branch) {
+  // ref = git tag or branch for the library under test (deps resolve from that ref's library.json)
+  setup: async function(library, ref, download) {
     const isUrl = ['http', 'git@'].includes(library.slice(0, 4)) ? true : false;
     const url = library;
     const missingOptionals = {};
@@ -196,25 +197,25 @@ const cli = {
         const entry = await this.register(url);
         library = logic.machineToShort(Object.keys(entry)[0]);
       }
-      // branch is interpolated into a git clone shell command, so reject unsafe refs
-      if (branch && !/^[\w./-]+$/.test(branch)) {
-        console.log(`> error: invalid branch name "${branch}"`);
+      // ref is interpolated into git clone shell commands, so reject unsafe characters
+      if (ref && !/^[\w./-]+$/.test(ref)) {
+        console.log(`> error: invalid ref "${ref}"`);
         return;
       }
       let toSkip = [];
       const action = parseInt(download) ? 'download' : 'clone';
-      const latest = version ? false : true;
-      let result = await logic.computeDependencies(library, 'view', version);
+      const latest = ref ? false : true;
+      let result = await logic.computeDependencies(library, 'view', ref);
       for (let item in result) {
         // setup editor dependencies for every view dependency
         if (!result[item].id) {
           handleMissingOptionals(missingOptionals, result, item);
         }
         else {
-          toSkip = await logic.getWithDependencies(action, item, 'edit', latest, toSkip, item === library ? branch : null);
+          toSkip = await logic.getWithDependencies(action, item, 'edit', latest, toSkip, item === library ? ref : null);
         }
       }
-      result = await logic.computeDependencies(library, 'edit', version);
+      result = await logic.computeDependencies(library, 'edit', ref);
       for (let item in result) {
         if (!result[item].id) {
           handleMissingOptionals(missingOptionals, result, item);
@@ -222,9 +223,9 @@ const cli = {
       }
       toSkip = [];
       console.log(`> ${action} ${library} library "view" dependencies into "${config.folders.libraries}" folder`);
-      toSkip = await logic.getWithDependencies(action, library, 'view', latest, toSkip, branch);
+      toSkip = await logic.getWithDependencies(action, library, 'view', latest, toSkip, ref);
       console.log(`> ${action} ${library} library "edit" dependencies into "${config.folders.libraries}" folder`);
-      toSkip = await logic.getWithDependencies(action, library, 'edit', latest, toSkip, branch);
+      toSkip = await logic.getWithDependencies(action, library, 'edit', latest, toSkip, ref);
       if (Object.keys(missingOptionals).length) {
         console.log('!!! missing optional libraries');
         for (let item in missingOptionals) {

--- a/cli.js
+++ b/cli.js
@@ -211,7 +211,7 @@ const cli = {
           handleMissingOptionals(missingOptionals, result, item);
         }
         else {
-          toSkip = await logic.getWithDependencies(action, item, 'edit', latest, toSkip);
+          toSkip = await logic.getWithDependencies(action, item, 'edit', latest, toSkip, item === library ? branch : null);
         }
       }
       result = await logic.computeDependencies(library, 'edit', version);

--- a/cli.js
+++ b/cli.js
@@ -204,7 +204,9 @@ const cli = {
       }
       let toSkip = [];
       const action = parseInt(download) ? 'download' : 'clone';
-      const latest = ref ? false : true;
+      // With a ref, pin deps to versions from that ref's library.json (clone falls back to
+      // master if the tag is missing). Without a ref, deps follow master as before.
+      const latest = !ref;
       let result = await logic.computeDependencies(library, 'view', ref);
       for (let item in result) {
         // setup editor dependencies for every view dependency
@@ -237,6 +239,7 @@ const cli = {
     catch (error) {
       console.log('> error');
       console.log(error);
+      process.exitCode = 1;
     }
   },
   // clone library branches in corresponding @branch folders

--- a/logic.js
+++ b/logic.js
@@ -424,8 +424,9 @@ module.exports = {
   /* clones/downloads dependencies to libraries folder using git and runs relevant npm commands
   mode - 'view' or 'edit' to fetch non-editor or editor libraries
   latest - if true master branch versions of libraries are used
-  toSkip - optional array of libraries to skip; after a library is parsed by the function it's auto-added to the array so it's skipped for efficiency */
-  getWithDependencies: async (action, library, mode, latest, toSkip = []) => {
+  toSkip - optional array of libraries to skip; after a library is parsed by the function it's auto-added to the array so it's skipped for efficiency
+  branch - optional git branch/ref to clone for the target library only; its dependencies still use master/tag */
+  getWithDependencies: async (action, library, mode, latest, toSkip = [], branch = null) => {
     const list = await module.exports.computeDependencies(library, mode);
     for (let item in list) {
       if (toSkip.indexOf(item) != -1) {
@@ -443,21 +444,24 @@ module.exports = {
       }
       const label = `${list[item].id}-${list[item].version.major}.${list[item].version.minor}`;
       const listVersion = `${list[item].version.major}.${list[item].version.minor}.${list[item].version.patch}`;
-      const version = latest ? 'master' : listVersion;
+      // only the library under test follows the PR branch; its deps stay on master/tag
+      const useBranch = branch && item === library;
+      const version = useBranch ? branch : (latest ? 'master' : listVersion);
       const folder = `${config.folders.libraries}/${label}`;
       if (fs.existsSync(folder)) {
-        if (latest && !process.env.H5P_NO_UPDATES) {
+        if (latest && !useBranch && !process.env.H5P_NO_UPDATES) {
           console.log(`>> ~ updating to ${list[item].repoName} ${listVersion}`);
           execSync(`git checkout master`, { cwd: folder, stdio : 'pipe' });
           console.log(execSync('git pull origin', { cwd: folder }).toString());
         }
         else {
-          console.log(`>> ~ skipping updates for ${list[item].repoName} ${listVersion}`);
+          // branch libs are intentionally left as-is on re-runs (fresh CI runners never hit this)
+          console.log(`>> ~ skipping updates for ${list[item].repoName} ${useBranch ? branch : listVersion}`);
         }
         continue;
       }
-      console.log(`>> + installing ${list[item].repoName} ${listVersion}`);
-      if (action == 'download') {
+      console.log(`>> + installing ${list[item].repoName} ${useBranch ? branch : listVersion}`);
+      if (action == 'download' && !useBranch) {
         await module.exports.download(list[item].org, list[item].repoName, version, folder);
       }
       else {

--- a/logic.js
+++ b/logic.js
@@ -330,23 +330,24 @@ module.exports = {
       }
       done[level][dep].requiredBy.push(requiredByPath);
       done[level][dep].level = level;
-      let ver = version == 'master' ? version : `${done[level][dep].version.major}.${done[level][dep].version.minor}.${done[level][dep].version.patch}`;
-      const optionals = await getOptionals(dep, org, repoName, ver, toDo[dep].folder);
+      // Fetch semantics from the same ref we used for library.json. Rewriting a branch
+      // name to major.minor.patch breaks when that patch is unreleased (no such tag).
+      const optionals = await getOptionals(dep, org, repoName, version, toDo[dep].folder);
       if (list.preloadedDependencies) {
         for (let item of list.preloadedDependencies) {
-          ver = version == 'master' ? version : `${item.majorVersion}.${item.minorVersion}`;
+          let ver = version == 'master' ? version : `${item.majorVersion}.${item.minorVersion}`;
           const dir = folder ? libraryDirs[item.machineName] : null;
           handleDepListEntry(item.machineName, dep, ver, dir);
         }
       }
       for (let item in optionals) {
-        ver = version == 'master' ? version : optionals[item].version;
+        let ver = version == 'master' ? version : optionals[item].version;
         const dir = folder ? libraryDirs[item] : null;
         handleDepListEntry(item, dep, ver, dir);
       }
       if (mode == 'edit' && list.editorDependencies) {
         for (let item of list.editorDependencies) {
-          ver = version == 'master' ? version : `${item.majorVersion}.${item.minorVersion}`;
+          let ver = version == 'master' ? version : `${item.majorVersion}.${item.minorVersion}`;
           const dir = folder ? libraryDirs[item.machineName] : null;
           handleDepListEntry(item.machineName, dep, ver, dir);
         }
@@ -427,7 +428,7 @@ module.exports = {
   latest - if true master branch versions of libraries are used
   toSkip - optional array of libraries to skip; after a library is parsed by the function it's auto-added to the array so it's skipped for efficiency
   ref - optional git tag/branch: dependency list is read from this ref's library.json;
-        only the target library is cloned at ref; dependencies install at the versions from that ref’s library.json (not at the same branch name) */
+        only the target library is cloned at ref; deps try that tree's versions, then master */
   getWithDependencies: async (action, library, mode, latest, toSkip = [], ref = null) => {
     const list = await module.exports.computeDependencies(library, mode, ref);
     for (let item in list) {
@@ -470,12 +471,25 @@ module.exports = {
         }
         continue;
       }
-      console.log(`>> + installing ${list[item].repoName} ${useRef ? ref : listVersion}`);
+      console.log(`>> + installing ${list[item].repoName} ${useRef ? version : listVersion}`);
       if (action == 'download' && !useRef) {
         await module.exports.download(list[item].org, list[item].repoName, version, folder);
       }
       else {
-        console.log(module.exports.clone(list[item].org, list[item].repoName, version, label));
+        try {
+          console.log(module.exports.clone(list[item].org, list[item].repoName, version, label));
+        }
+        catch (error) {
+          // Target ref must exist; deps may reference untagged patches in library.json.
+          if (useRef || version === 'master') {
+            throw error;
+          }
+          console.log(`>> ! ${list[item].repoName} ${version} not found, falling back to master`);
+          if (fs.existsSync(folder)) {
+            fs.rmSync(folder, { recursive: true, force: true });
+          }
+          console.log(module.exports.clone(list[item].org, list[item].repoName, 'master', label));
+        }
       }
       const packageFile = `${folder}/package.json`;
       if (!fs.existsSync(packageFile)) {

--- a/logic.js
+++ b/logic.js
@@ -444,7 +444,7 @@ module.exports = {
       }
       const label = `${list[item].id}-${list[item].version.major}.${list[item].version.minor}`;
       const listVersion = `${list[item].version.major}.${list[item].version.minor}.${list[item].version.patch}`;
-      // only the library under test follows the PR branch; its deps stay on master/tag
+
       const useBranch = branch && item === library;
       const version = useBranch ? branch : (latest ? 'master' : listVersion);
       const folder = `${config.folders.libraries}/${label}`;
@@ -455,7 +455,6 @@ module.exports = {
           console.log(execSync('git pull origin', { cwd: folder }).toString());
         }
         else {
-          // branch libs are intentionally left as-is on re-runs (fresh CI runners never hit this)
           console.log(`>> ~ skipping updates for ${list[item].repoName} ${useBranch ? branch : listVersion}`);
         }
         continue;

--- a/logic.js
+++ b/logic.js
@@ -65,7 +65,8 @@ const getFile = async (source, parseJson) => {
 // clone repo and retrieve file
 const getRepoFile = (gitUrl, path, branch = 'master', parseJson, cleanStart) => {
   const { repoName } = parseGitUrl(gitUrl);
-  const target = `${config.folders.temp}/${repoName}_${branch}`;
+  // Sanitize ref for the temp folder name so branches with "/" (feat/foo) don't create nested paths.
+  const target = `${config.folders.temp}/${repoName}_${String(branch).replace(/[^\w.-]/g, '_')}`;
   const filePath = `${target}/${path}`;
   if (cleanStart) {
     fs.rmSync(target, { recursive: true, force: true });
@@ -425,9 +426,10 @@ module.exports = {
   mode - 'view' or 'edit' to fetch non-editor or editor libraries
   latest - if true master branch versions of libraries are used
   toSkip - optional array of libraries to skip; after a library is parsed by the function it's auto-added to the array so it's skipped for efficiency
-  branch - optional git branch/ref to clone for the target library only; its dependencies still use master/tag */
-  getWithDependencies: async (action, library, mode, latest, toSkip = [], branch = null) => {
-    const list = await module.exports.computeDependencies(library, mode);
+  ref - optional git tag/branch: dependency list is read from this ref's library.json;
+        only the target library is cloned at ref; dependencies install at the versions from that ref’s library.json (not at the same branch name) */
+  getWithDependencies: async (action, library, mode, latest, toSkip = [], ref = null) => {
+    const list = await module.exports.computeDependencies(library, mode, ref);
     for (let item in list) {
       if (toSkip.indexOf(item) != -1) {
         continue;
@@ -445,22 +447,31 @@ module.exports = {
       const label = `${list[item].id}-${list[item].version.major}.${list[item].version.minor}`;
       const listVersion = `${list[item].version.major}.${list[item].version.minor}.${list[item].version.patch}`;
 
-      const useBranch = branch && item === library;
-      const version = useBranch ? branch : (latest ? 'master' : listVersion);
+      const useRef = ref && item === library;
+      let version;
+      if (useRef) {
+        version = ref;
+      }
+      else if (latest) {
+        version = 'master';
+      }
+      else {
+        version = listVersion;
+      }
       const folder = `${config.folders.libraries}/${label}`;
       if (fs.existsSync(folder)) {
-        if (latest && !useBranch && !process.env.H5P_NO_UPDATES) {
+        if (latest && !useRef && !process.env.H5P_NO_UPDATES) {
           console.log(`>> ~ updating to ${list[item].repoName} ${listVersion}`);
           execSync(`git checkout master`, { cwd: folder, stdio : 'pipe' });
           console.log(execSync('git pull origin', { cwd: folder }).toString());
         }
         else {
-          console.log(`>> ~ skipping updates for ${list[item].repoName} ${useBranch ? branch : listVersion}`);
+          console.log(`>> ~ skipping updates for ${list[item].repoName} ${useRef ? ref : listVersion}`);
         }
         continue;
       }
-      console.log(`>> + installing ${list[item].repoName} ${useBranch ? branch : listVersion}`);
-      if (action == 'download' && !useBranch) {
+      console.log(`>> + installing ${list[item].repoName} ${useRef ? ref : listVersion}`);
+      if (action == 'download' && !useRef) {
         await module.exports.download(list[item].org, list[item].repoName, version, folder);
       }
       else {


### PR DESCRIPTION
H5PT-227 Add optional branch arg to setup

Let `h5p setup` clone the target content type from a specific git
branch instead of only master or a release tag.

This is ment to mainly be used in test automation, so another option was considering, adding this logic in the ci-workflows repo. This did seem to violate responsibility splitting though, so it seemed more fitting to add this logic here.

Usage:
  `h5p setup h5p-true-false fix/my-bug-branch` or with tag; `h5p setup h5p-true-false 1.8.35`
