### PR TITLE
Fix dependency computation by topological sorting

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -105,6 +105,57 @@ const getFileList = (folder) => {
   }
   return output;
 }
+
+/**
+ * Order nodes, so dependencies precede dependents.
+ * @param {string[]} nodeKeys Keys of nodes to sort.
+ * @param {function} getDependencyKeys Function returning dependency keys of given node key.
+ * @param {string[]} fallbackOrder Keys in the order to prefer when multiple nodes are ready at once or a circular dependency needs to be broken.
+ * @returns {string[]} Node keys ordered so dependencies precede dependents.
+ */
+const topologicalSort = (nodeKeys, getDependencyKeys, fallbackOrder) => {
+  const priority = {};
+  fallbackOrder.forEach((key, index) => {
+    if (!(key in priority)) {
+      priority[key] = index;
+    }
+  });
+
+  const nodes = new Set(nodeKeys);
+  const dependents = {}; // dependency key -> Set of keys that require it
+  const inDegree = {};
+
+  nodes.forEach((node) => {
+    inDegree[node] = 0;
+  });
+
+  nodes.forEach((node) => {
+    for (let dep of getDependencyKeys(node)) {
+      if (dep === node || !nodes.has(dep) || dependents[dep]?.has(node)) {
+        continue;
+      }
+      dependents[dep] = dependents[dep] || new Set();
+      dependents[dep].add(node);
+      inDegree[node]++;
+    }
+  });
+
+  const remaining = new Set(nodes);
+  const sorted = [];
+  while (remaining.size) {
+    const ready = [...remaining].filter((node) => inDegree[node] === 0);
+    if (!ready.length) {
+      module.exports.write('\n!!! circular library dependency detected while ordering scripts; falling back to heuristic order for the remainder ');
+    }
+    const next = (ready.length ? ready : [...remaining]).sort((a, b) => priority[a] - priority[b])[0];
+    sorted.push(next);
+    remaining.delete(next);
+    (dependents[next] || []).forEach((dependent) => inDegree[dependent]--);
+  }
+
+  return sorted;
+}
+
 module.exports = {
   // debug console log
   log: function (message) {
@@ -366,6 +417,7 @@ module.exports = {
       }
     }
     let output = {};
+    const heuristicOrder = [];
     for (let i = level; i >= 0; i--) {
       const keys = Object.keys(done[i]);
       keys.sort((a, b) => {
@@ -375,13 +427,26 @@ module.exports = {
         if (!output[key] || output[key]?.optional) {
           output[key] = done[i][key];
         }
-        if (!done[i][key].id) {
-          continue;
-        }
+        heuristicOrder.push(key);
       }
     }
+
+    const dependencyKeysOf = (key) => {
+      const dependencyEntries = [...(output[key].preloadedDependencies || [])];
+      if (mode === 'edit') {
+        dependencyEntries.push(...(output[key].editorDependencies || []));
+      }
+      return dependencyEntries.map((entry) => registry.reversed[entry.machineName]?.shortName).filter(Boolean);
+    };
+
+    const sortedOutput = {};
+    for (let key of topologicalSort(Object.keys(output), dependencyKeysOf, heuristicOrder)) {
+      sortedOutput[key] = output[key];
+    }
+
     module.exports.write('\n');
-    return output;
+
+    return sortedOutput;
   },
   // list tags for library using git
   tags: (org, repo, mainBranch = 'master') => {


### PR DESCRIPTION
Thank you for your interest in contributing to H5P! 🎉  
Please fill in the below sections to make your pull request:

**What kind of change does this PR introduce?**
Bug: Dependencies do not get loaded in correct order, e.g. H5P.Question before JoubelUI which then causes crashes when H5P.Question wants to use JoubelUI.

**What is the current behaviour?**
The dependency computation that compiles the list of scripts to be loaded sorts on a depth-level-first approach and then by reference count within the same level. This works well in many cases, but does not guarantee a valid dependency order.

For example, `H5P.Question` and `H5P.JoubelUI` are both used by several other content types. Because of that, they both end up grouped together at the same "level" in the dependency tree. Within that group, the one that's used by more content types is simply listed first — and in this case that happens to be `H5P.Question`, even though `H5P.Question` itself needs `H5P.JoubelUI` to already be loaded. The cli tool has no way of knowing that a relationship like this exists between two entries that landed in the same group, so it can get the order backwards. When that happens, `H5P.JoubelUI` isn't available yet when `H5P.Question` runs, which breaks anything in H5P.Question that relies on it.

**What is the new behaviour?**
After computing the existing level + weight order (kept as a fallback), `computeDependencies` now runs a topological sort over the actual dependencies recorded for each library. This guarantees a library's own dependencies always precede it in the returned order. The original level + weight order is still used to break ties between independent libraries and, if a circular dependency is ever encountered, to deterministically resolve it instead of hanging or producing undefined ordering.

Net effect (what my issue was): joubel-ui.js now consistently loads before question.js with no change to load order for libraries that aren't affected by this edge case.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
