### PR TITLE
Fix/va 1763 branches update

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -250,6 +250,9 @@ const cli = {
       const initialBranch = execSync('git rev-parse --abbrev-ref HEAD').toString();
       const branches = process.argv.slice(3);
       const validBranches = [];
+      // Ensure origin is up to date
+      execSync('git fetch origin');
+
       for (let branch of branches) {
         const target = `@${branch.replace('/', '_')}`;
         const tmpTarget = `/tmp/h5p-cli-${target}`;

--- a/cli.js
+++ b/cli.js
@@ -255,9 +255,11 @@ const cli = {
         const tmpTarget = `/tmp/h5p-cli-${target}`;
 
         let checkoutRef = branch;
+        let hasLocal = true;
 
         if (!gitRefExists(branch)) {
           if (!branch.includes('/') && gitRefExists(`origin/${branch}`)) {
+            hasLocal = false;
             checkoutRef = `origin/${branch}`;
           }
           else {
@@ -267,6 +269,9 @@ const cli = {
         }
 
         execSync(`git checkout ${checkoutRef}`);
+        if (hasLocal) {
+          execSync('git pull');
+        }
         fs.rmSync(tmpTarget, { recursive: true, force: true });
         execSync(`cp -r . ${tmpTarget}`);
         validBranches.push(branch);

--- a/cli.js
+++ b/cli.js
@@ -250,8 +250,17 @@ const cli = {
       const initialBranch = execSync('git rev-parse --abbrev-ref HEAD').toString();
       const branches = process.argv.slice(3);
       const validBranches = [];
+      const remotes = execSync('git remote', { encoding: 'utf8' })
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean);
+      const hasOrigin = remotes.includes('origin');
+      const hasAnyRemote = remotes.length > 0;
+
       // Ensure origin is up to date
-      execSync('git fetch origin');
+      if (hasOrigin) {
+        execSync('git fetch origin');
+      }
 
       for (let branch of branches) {
         const target = `@${branch.replace('/', '_')}`;
@@ -272,8 +281,8 @@ const cli = {
         }
 
         execSync(`git checkout ${checkoutRef}`);
-        if (hasLocal) {
-          execSync('git pull');
+        if (hasLocal && hasAnyRemote) {
+          execSync('git pull --ff-only');
         }
         fs.rmSync(tmpTarget, { recursive: true, force: true });
         execSync(`cp -r . ${tmpTarget}`);

--- a/h5p.js
+++ b/h5p.js
@@ -8,7 +8,7 @@ const setupFolders = () => {
     }
   }
 }
-if (![undefined, 'utils', 'help'].includes(process.argv[2])) {
+if (['core', 'setup', 'clone', 'install'].includes(process.argv[2])) {
   setupFolders();
 }
 require('./cli.js');


### PR DESCRIPTION
Thank you for your interest in contributing to H5P! 🎉  
Please fill in the below sections to make your pull request:

**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
There are two issues:
1. `h5p @branches <branch>`-command does not necessarily get the latest version of that branch. If you have a local checkout it merely switches to that branch.
2. Almost all commands will now setup the base folders if they are not detected. This happens e.g. simply when doing the `h5p @branches <branch>`-command. It can also be frustrating if you accidentally do a command in the wrong folder. The command should just fail without creating unnecessary folders.

**What is the new behaviour?**
1. `h5p @branches <branch>`-command now does a `git fetch origin` so that if we check out a remote (origin) branch it is the latest one and if we use a local copy we do a `git pull`. 
2. We're doing quite a change here. We will only do the setup folders for `core`, `setup`, `install` and `clone` which require the `libraries` folder. We could perhaps look into having a separate command just for setting up the folders. 

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
