### PR TITLE
Add --content-only and --output options to export

### DIFF
--- a/assets/docs/commands.md
+++ b/assets/docs/commands.md
@@ -87,17 +87,17 @@ The command also updates the preloaded `library.json` entries to include those f
 `[port]` is an optional port number. Default is 8080.  
 Once the dev server is started you can use your browser to view, edit, delete, import, export and create new content types.  
 
-• `h5p export <library> <folder> [--mini] [--output <directory>]` will export the `<library>` content type from the `content/<folder>` folder.
+• `h5p export <library> <folder> [--content-only] [--output <directory>]` will export the `<library>` content type from the `content/<folder>` folder.
 An example is `h5p export h5p-agamotto agamotto-test`, which will export the `h5p-agamotto` content type located in the `content/agamotto-test` folder.
 Make sure that the library's dependencies are installed.
 
-Use `--mini` to export the content without bundling any H5P libraries. This is useful when the required libraries are already installed in the target H5P environment.
-Example: `h5p export h5p-agamotto agamotto-test --mini`
+Use `--content-only` to export the content without bundling any H5P libraries. This is useful when the required libraries are already installed in the target H5P environment.
+Example: `h5p export h5p-agamotto agamotto-test --content-only`
 
 Use `--output <directory>` to save the resulting `.h5p` file in a specific directory instead of the default temporary directory.
-Example: `h5p export h5p-agamotto agamotto-test --mini --output C:\Users\josep\Downloads`
+Example: `h5p export h5p-agamotto agamotto-test --content-only --output ~/Downloads`
 
-The `--mini` and `--output` options may be used independently or together, in either order.
+The `--content-only` and `--output` options may be used independently or together, in either order.
 Once finished, the export command outputs the location of the resulting file.
 
 • `h5p import <folder> <h5p_archive_file_path>` will import the archived .h5p `<h5p_archive_file_path>` content type into the `content/<folder>` folder.  

--- a/assets/docs/commands.md
+++ b/assets/docs/commands.md
@@ -90,13 +90,10 @@ Once the dev server is started you can use your browser to view, edit, delete, i
 • `h5p export <library> <folder> [--content-only] [--output <directory>]` will export the `<library>` content type from the `content/<folder>` folder.
 An example is `h5p export h5p-agamotto agamotto-test`, which will export the `h5p-agamotto` content type located in the `content/agamotto-test` folder.
 Make sure that the library's dependencies are installed.
-
 Use `--content-only` to export the content without bundling any H5P libraries. This is useful when the required libraries are already installed in the target H5P environment.
 Example: `h5p export h5p-agamotto agamotto-test --content-only`
-
 Use `--output <directory>` to save the resulting `.h5p` file in a specific directory instead of the default temporary directory.
 Example: `h5p export h5p-agamotto agamotto-test --content-only --output ~/Downloads`
-
 The `--content-only` and `--output` options may be used independently or together, in either order.
 Once finished, the export command outputs the location of the resulting file.
 

--- a/assets/docs/commands.md
+++ b/assets/docs/commands.md
@@ -87,10 +87,18 @@ The command also updates the preloaded `library.json` entries to include those f
 `[port]` is an optional port number. Default is 8080.  
 Once the dev server is started you can use your browser to view, edit, delete, import, export and create new content types.  
 
-• `h5p export <library> <folder>` will export the `<library>` content type from the `content/<folder>` folder.  
-An example here is `h5p export h5p-agamotto agamotto-test` which will export the `h5p-agamotto` content type located in the `content/agamotto-test` folder.  
-Make sure that the library's dependencies are installed.  
-Once finished, the export command outputs the location of the resulting file.  
+• `h5p export <library> <folder> [--mini] [--output <directory>]` will export the `<library>` content type from the `content/<folder>` folder.
+An example is `h5p export h5p-agamotto agamotto-test`, which will export the `h5p-agamotto` content type located in the `content/agamotto-test` folder.
+Make sure that the library's dependencies are installed.
+
+Use `--mini` to export the content without bundling any H5P libraries. This is useful when the required libraries are already installed in the target H5P environment.
+Example: `h5p export h5p-agamotto agamotto-test --mini`
+
+Use `--output <directory>` to save the resulting `.h5p` file in a specific directory instead of the default temporary directory.
+Example: `h5p export h5p-agamotto agamotto-test --mini --output C:\Users\josep\Downloads`
+
+The `--mini` and `--output` options may be used independently or together, in either order.
+Once finished, the export command outputs the location of the resulting file.
 
 • `h5p import <folder> <h5p_archive_file_path>` will import the archived .h5p `<h5p_archive_file_path>` content type into the `content/<folder>` folder.  
 An example here is `h5p import agamotto-test ~/Downloads/agamotto_test.h5p` which will import the `~/Downloads/agamotto_test.h5p` archived .h5p file into the `content/agamotto-test` folder.  

--- a/cli.js
+++ b/cli.js
@@ -43,12 +43,20 @@ const cli = {
   // exports content type as .h5p zipped file
   export: async (library, folder, ...options) => {
     try {
-      const mini = options.includes('--mini');
-
+      const contentOnly = options.includes('--content-only');
       const outputIndex = options.indexOf('--output');
-      const output = outputIndex !== -1 ? options[outputIndex + 1] : null;
 
-      const file = await logic.export(library, folder, mini, output);
+      let output = null;
+
+      if (outputIndex !== -1) {
+        output = options[outputIndex + 1];
+
+        if (!output || output.startsWith('--')) {
+          throw new Error('The --output option requires a valid directory path.');
+        }
+      }
+
+      const file = await logic.export(library, folder, contentOnly, output);
       console.log(file);
     }
     catch (error) {

--- a/cli.js
+++ b/cli.js
@@ -41,9 +41,14 @@ const handleMissingOptionals = (missingOptionals, result, item) => {
 };
 const cli = {
   // exports content type as .h5p zipped file
-  export: async (library, folder) => {
+  export: async (library, folder, ...options) => {
     try {
-      const file = await logic.export(library, folder);
+      const mini = options.includes('--mini');
+
+      const outputIndex = options.indexOf('--output');
+      const output = outputIndex !== -1 ? options[outputIndex + 1] : null;
+
+      const file = await logic.export(library, folder, mini, output);
       console.log(file);
     }
     catch (error) {

--- a/logic.js
+++ b/logic.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const nodePath = require('path');
 const { execSync } = require("child_process");
 const fs = require('fs');
 const superAgent = require('superagent');
@@ -133,90 +133,43 @@ module.exports = {
   },
   // creates zip archive export file in the .h5p format
   export: async (library, folder, contentOnly = false, output = null) => {
-    const target = path.join(config.folders.temp, folder);
-
+    const target = `${config.folders.temp}/${folder}`;
     fs.rmSync(target, { recursive: true, force: true });
     fs.mkdirSync(target);
-
-    fs.cpSync(
-      path.join('content', folder),
-      path.join(target, 'content'),
-      { recursive: true }
-    );
-
-    fs.renameSync(
-      path.join(target, 'content', 'h5p.json'),
-      path.join(target, 'h5p.json')
-    );
-
-    fs.rmSync(
-      path.join(target, 'content', 'sessions'),
-      { recursive: true, force: true }
-    );
-
+    fs.cpSync(`content/${folder}`, `${target}/content`, { recursive: true });
+    fs.renameSync(`${target}/content/h5p.json`, `${target}/h5p.json`);
+    fs.rmSync(`${target}/content/sessions`, { recursive: true, force: true });
     if (!contentOnly) {
       const registry = await module.exports.getRegistry();
       const libraryDirs = await module.exports.parseLibraryFolders();
       const libFolder = libraryDirs[registry.regular[library].id];
-
-      let libs = await module.exports.computeDependencies(
-        library,
-        'view',
-        null,
-        libFolder
-      );
-      const editLibs = await module.exports.computeDependencies(
-        library,
-        'edit',
-        null,
-        libFolder
-      );
-
+      let libs = await module.exports.computeDependencies(library, 'view', null, libFolder);
+      const editLibs = await module.exports.computeDependencies(library, 'edit', null, libFolder);
       libs = {...libs, ...editLibs};
-
       for (let item in libs) {
-        const libraryFolder = libraryDirs[libs[item].id];
-
-        fs.cpSync(
-          path.join(config.folders.libraries, libraryFolder),
-          path.join(target, libraryFolder),
-          { recursive: true }
-        );
+        const folder = libraryDirs[libs[item].id];
+        fs.cpSync(`${config.folders.libraries}/${folder}`, `${target}/${folder}`, { recursive: true });
       }
     }
-
     const files = getFileList(target);
     const zip = new admZip();
-
     for (let item of files) {
       const file = item;
       item = item.replace(target, '');
-
-      let archivePath = item.split('/');
-      const name = archivePath.pop();
-
-      if (
-        config.files.patterns.ignored.test(name) ||
-        !config.files.patterns.allowed.test(name)
-      ) {
+      let path = item.split('/');
+      const name = path.pop();
+      if (config.files.patterns.ignored.test(name) || !config.files.patterns.allowed.test(name)) {
         continue;
       }
-
-      archivePath = archivePath.join('/');
-      zip.addLocalFile(file, archivePath);
+      path = path.join('/');
+      zip.addLocalFile(file, path);
     }
-
-    const zipped = output
-      ? path.join(output, `${folder}.h5p`)
-      : `${target}.h5p`;
-
+    const zipped = output ? nodePath.join(output, `${folder}.h5p`) : `${target}.h5p`;
     if (output) {
       fs.mkdirSync(output, { recursive: true });
     }
-
     zip.writeZip(zipped);
     fs.rmSync(target, { recursive: true, force: true });
-
     return zipped;
   },
   /* retrieves list of h5p librarie

--- a/logic.js
+++ b/logic.js
@@ -131,37 +131,54 @@ module.exports = {
     return folder;
   },
   // creates zip archive export file in the .h5p format
-  export: async (library, folder) => {
-    const registry = await module.exports.getRegistry();
-    const libraryDirs = await module.exports.parseLibraryFolders();
-    const libFolder = libraryDirs[registry.regular[library].id];
+  export: async (library, folder, mini = false, output = null) => {
     const target = `${config.folders.temp}/${folder}`;
     fs.rmSync(target, { recursive: true, force: true });
     fs.mkdirSync(target);
     fs.cpSync(`content/${folder}`, `${target}/content`, { recursive: true });
     fs.renameSync(`${target}/content/h5p.json`, `${target}/h5p.json`);
     fs.rmSync(`${target}/content/sessions`, { recursive: true, force: true });
-    let libs = await module.exports.computeDependencies(library, 'view', null, libFolder);
-    const editLibs = await module.exports.computeDependencies(library, 'edit', null, libFolder);
-    libs = {...libs, ...editLibs};
-    for (let item in libs) {
-      const folder = libraryDirs[libs[item].id];
-      fs.cpSync(`${config.folders.libraries}/${folder}`, `${target}/${folder}`, { recursive: true });
+
+    if (!mini) {
+      const registry = await module.exports.getRegistry();
+      const libraryDirs = await module.exports.parseLibraryFolders();
+      const libFolder = libraryDirs[registry.regular[library].id];
+
+      let libs = await module.exports.computeDependencies(library, 'view', null, libFolder);
+      const editLibs = await module.exports.computeDependencies(library, 'edit', null, libFolder);
+
+      libs = {...libs, ...editLibs};
+
+      for (let item in libs) {
+        const folder = libraryDirs[libs[item].id];
+        fs.cpSync(`${config.folders.libraries}/${folder}`, `${target}/${folder}`, { recursive: true });
+      }
     }
+
     const files = getFileList(target);
     const zip = new admZip();
+
     for (let item of files) {
       const file = item;
       item = item.replace(target, '');
       let path = item.split('/');
       const name = path.pop();
+
       if (config.files.patterns.ignored.test(name) || !config.files.patterns.allowed.test(name)) {
         continue;
       }
+
       path = path.join('/');
       zip.addLocalFile(file, path);
     }
-    const zipped = `${target}.h5p`;
+    const zipped = output
+      ? `${output}/${folder}.h5p`
+      : `${target}.h5p`;
+
+    if (output) {
+      fs.mkdirSync(output, { recursive: true });
+    }
+
     zip.writeZip(zipped);
     fs.rmSync(target, { recursive: true, force: true });
     return zipped;

--- a/logic.js
+++ b/logic.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const { execSync } = require("child_process");
 const fs = require('fs');
 const superAgent = require('superagent');
@@ -131,27 +132,56 @@ module.exports = {
     return folder;
   },
   // creates zip archive export file in the .h5p format
-  export: async (library, folder, mini = false, output = null) => {
-    const target = `${config.folders.temp}/${folder}`;
+  export: async (library, folder, contentOnly = false, output = null) => {
+    const target = path.join(config.folders.temp, folder);
+
     fs.rmSync(target, { recursive: true, force: true });
     fs.mkdirSync(target);
-    fs.cpSync(`content/${folder}`, `${target}/content`, { recursive: true });
-    fs.renameSync(`${target}/content/h5p.json`, `${target}/h5p.json`);
-    fs.rmSync(`${target}/content/sessions`, { recursive: true, force: true });
 
-    if (!mini) {
+    fs.cpSync(
+      path.join('content', folder),
+      path.join(target, 'content'),
+      { recursive: true }
+    );
+
+    fs.renameSync(
+      path.join(target, 'content', 'h5p.json'),
+      path.join(target, 'h5p.json')
+    );
+
+    fs.rmSync(
+      path.join(target, 'content', 'sessions'),
+      { recursive: true, force: true }
+    );
+
+    if (!contentOnly) {
       const registry = await module.exports.getRegistry();
       const libraryDirs = await module.exports.parseLibraryFolders();
       const libFolder = libraryDirs[registry.regular[library].id];
 
-      let libs = await module.exports.computeDependencies(library, 'view', null, libFolder);
-      const editLibs = await module.exports.computeDependencies(library, 'edit', null, libFolder);
+      let libs = await module.exports.computeDependencies(
+        library,
+        'view',
+        null,
+        libFolder
+      );
+      const editLibs = await module.exports.computeDependencies(
+        library,
+        'edit',
+        null,
+        libFolder
+      );
 
       libs = {...libs, ...editLibs};
 
       for (let item in libs) {
-        const folder = libraryDirs[libs[item].id];
-        fs.cpSync(`${config.folders.libraries}/${folder}`, `${target}/${folder}`, { recursive: true });
+        const libraryFolder = libraryDirs[libs[item].id];
+
+        fs.cpSync(
+          path.join(config.folders.libraries, libraryFolder),
+          path.join(target, libraryFolder),
+          { recursive: true }
+        );
       }
     }
 
@@ -161,18 +191,23 @@ module.exports = {
     for (let item of files) {
       const file = item;
       item = item.replace(target, '');
-      let path = item.split('/');
-      const name = path.pop();
 
-      if (config.files.patterns.ignored.test(name) || !config.files.patterns.allowed.test(name)) {
+      let archivePath = item.split('/');
+      const name = archivePath.pop();
+
+      if (
+        config.files.patterns.ignored.test(name) ||
+        !config.files.patterns.allowed.test(name)
+      ) {
         continue;
       }
 
-      path = path.join('/');
-      zip.addLocalFile(file, path);
+      archivePath = archivePath.join('/');
+      zip.addLocalFile(file, archivePath);
     }
+
     const zipped = output
-      ? `${output}/${folder}.h5p`
+      ? path.join(output, `${folder}.h5p`)
       : `${target}.h5p`;
 
     if (output) {
@@ -181,6 +216,7 @@ module.exports = {
 
     zip.writeZip(zipped);
     fs.rmSync(target, { recursive: true, force: true });
+
     return zipped;
   },
   /* retrieves list of h5p librarie


### PR DESCRIPTION
Thank you for your interest in contributing to H5P! 🎉

**What kind of change does this PR introduce?**

Feature / CLI enhancement.

Adds two optional flags to the `h5p export` command:

- `--content-only` exports H5P content without bundling library dependencies.
- `--output <directory>` writes the resulting `.h5p` file to a specified directory instead of the default temp directory.

Both options can be used independently or together, in either order.

**What is the current behaviour?**

The normal export process computes both view and editor dependencies and copies all dependent libraries into the resulting `.h5p` package.

For development workflows where the target H5P environment already has the required libraries installed, this can make exports unnecessarily slow and produce unnecessarily large packages.

The exported file is also always written to the configured temp directory.

**What is the new behaviour?**

The existing export behaviour remains unchanged when no options are supplied.

Using:

`h5p export <library> <folder> --content-only`

exports the content metadata and assets without bundling H5P libraries. This is intended for environments where the required libraries are already installed.

Using:

`h5p export <library> <folder> --output <directory>`

writes the resulting `.h5p` file to the specified directory.

The options can also be combined:

`h5p export <library> <folder> --content-only--output <directory>`

The changes were tested locally with:
- normal export
- `--content-only`
- `--output`
- `--content-only --output`
- reversed option order
- import of a content-only package into an environment where the required libraries were already installed

Normal export was verified to continue including the complete dependency set.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [ ] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.