### PR TITLE
Fix editor library translations

### DIFF
--- a/api.js
+++ b/api.js
@@ -817,7 +817,9 @@ const ajaxLibraries = async (options) => {
       title: libs[library].title,
       upgradesScript: `${baseUrl}/${config.folders.libraries}/${folder}/upgrades.js`,
       semantics: JSON.parse(fs.readFileSync(`${config.folders.libraries}/${folder}/semantics.json`, 'utf-8')),
-      language: null,
+      language: preloaded[0].translations[libs[library].id]
+        ? JSON.stringify(preloaded[0].translations[libs[library].id])
+        : null,
       defaultLanguage: null,
       languages: preloaded[0].languages,
       javascript: preloaded[0].preloadedJs,


### PR DESCRIPTION
Thank you for your interest in contributing to H5P! 🎉

**What kind of change does this PR introduce?**

Bug fix.

**What is the current behaviour?**

When a language is selected in the H5P CLI dashboard, the H5P editor interface is only partially translated. Content type field labels and other strings defined in the library's language file may remain in English.

This is the issue reported in #123 and tracked internally as HFP-4170.

`ajaxLibraries()` currently returns `language: null`, causing the H5P editor to fall back to the English strings from `semantics.json`.

**What is the new behaviour?**

`ajaxLibraries()` now returns the selected library translation as the JSON string expected by the H5P editor.

The change was manually tested with French, Spanish and Italian. Switching back to English also works as before.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.