### PR TITLE
Fix editor important instructions state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ package-lock.json
 /temp/*
 /uploads/*
 /content/*
+/.h5p-editor-user-data.json

--- a/api.js
+++ b/api.js
@@ -89,6 +89,40 @@ module.exports = {
       handleError(error, response);
     }
   },
+  // stores editor UI preferences such as important-description state
+  setEditorUserData: (request, response, next) => {
+    try {
+      const userData = getEditorUserData();
+      const key = `${request.params.type}/${request.params.subContentId}`;
+
+      userData[key] = request.body.data;
+
+      fs.writeFileSync(editorUserDataFile, JSON.stringify(userData));
+
+      response.set('Content-Type', 'application/json');
+      response.end(JSON.stringify({ success: true }));
+    }
+    catch (error) {
+      handleError(error, response);
+    }
+  },
+
+  // retrieves editor UI preferences such as important-description state
+  getEditorUserData: (request, response, next) => {
+    try {
+      const userData = getEditorUserData();
+      const key = `${request.params.type}/${request.params.subContentId}`;
+
+      response.set('Content-Type', 'application/json');
+      response.end(JSON.stringify({
+        success: true,
+        data: userData[key] ?? false
+      }));
+    }
+    catch (error) {
+      handleError(error, response);
+    }
+  },
   // updates session file used for resume functionality
   setUserData: (request, response, next) => {
     try {
@@ -845,6 +879,16 @@ const ajaxLibraries = async (options) => {
   }
   return output;
 }
+const editorUserDataFile = '.h5p-editor-user-data.json';
+
+const getEditorUserData = () => {
+  if (!fs.existsSync(editorUserDataFile)) {
+    return {};
+  }
+
+  return JSON.parse(fs.readFileSync(editorUserDataFile, 'utf-8'));
+};
+
 const handleError = (error, response) => {
   console.log(error);
   response.set('Content-Type', 'application/json');

--- a/server.js
+++ b/server.js
@@ -24,6 +24,14 @@ app.get('/edit/:library/:folder', api.edit);
 app.post('/edit/:library/:folder/libraries', api.ajaxLibraries);
 app.post('/edit/:library/:folder/files', multer.single('file'), api.uploadFile);
 app.post('/edit/:library/:folder', multer.none(), api.saveContent);
+app.get(
+  '/h5p-ajax/content-user-data/:contentId/:type/:subContentId',
+  api.getEditorUserData
+);
+app.post(
+  '/h5p-ajax/content-user-data/:contentId/:type/:subContentId',
+  api.setEditorUserData
+);
 app.get('/content-user-data/:folder/:type/:id', api.getUserData);
 app.post('/content-user-data/:folder/:type/:id', api.setUserData);
 app.delete('/content-user-data/:folder', api.resetUserData);


### PR DESCRIPTION
Thank you for your interest in contributing to H5P! 🎉

**What kind of change does this PR introduce?**

Bug fix.

**What is the current behaviour?**

In Edit mode, H5P content types that use an "Important instructions" field trigger requests to:

`/h5p-ajax/content-user-data/:contentId/:dataType/:subContentId`

H5P CLI does not currently implement this endpoint, so the requests return 404 and the Show/Hide state cannot be persisted through the H5P user-data API.

This is the issue reported in #101.

**What is the new behaviour?**

H5P CLI now implements GET and POST handlers for the editor user-data endpoint.

The editor can persist and retrieve UI preferences such as the "Important instructions" Show/Hide state. The data is stored in a local `.h5p-editor-user-data.json` file, which is ignored by Git.

Manually tested with an H5P content type using the "Important instructions" field:

- GET requests return 200
- POST requests return 200
- Show/Hide state is restored after reloading the editor
- both visible and hidden states can be persisted

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.